### PR TITLE
Fill some documentation gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,21 @@ This is not the offical documentation for Agon Light or its firmware Quark. You 
 
 ## Want to contribute?
 
-Great, please go to the [github repository](https://github.com/AgonConsole8/agon-docs) and create a Pullrequest with your changes.
+Great, please go to the [github repository](https://github.com/AgonConsole8/agon-docs) and create a Pull Request with your changes.
 
-## What is the Agon Light
+## What is the Agon Light, and what is the Agon Console8
 
-The Agon Light is a modern, fully open-source, 8-bit microcomputer and microcontroller in one small, low-cost board, designed by Bernado Kastrup aka The Byte Attic. As a computer, it is a standalone device that requires no host PC: it puts out its own video (VGA), audio (2 identical mono channels), accepts a PS/2 keyboard and has its own mass-storage in the form of a µSD card.
+The Agon Light is a modern, fully open-source, 8-bit microcomputer and microcontroller in one small, low-cost board, designed by Bernado Kastrup aka The Byte Attic. As a computer, it is a standalone device that requires no host PC: it puts out its own video (VGA), audio (2 identical mono channels), accepts a PS/2 keyboard and has its own mass-storage in the form of a µSD card.  The Olimex Agon Light 2 and the Agon Light Origins edition are variations on the original Agon Light design.
+
+The Agon Console8 is a version of the Agon Light that also includes two Atari-compatible joystick ports, and a PS/2 mouse port, and a stylish case.  It was also designed by Bernado Kastrup aka The Byte Attic, and is manufactured by Heber Ltd.
+
+The Agon Light, Olimex Agon Light 2, and the Agon Console8 are all fully compatible with each other.  Software written for one will run on the other, and the same firmware can be used on both.  In this documentation, generally, the term "Agon Light" is used to refer to all variations.
 
 The main CPU is an eZ80F92, a modern Zilog Z80 microcontroller that is fully backwards compatible with the Z80. As well as running in a traditional 8-bit mode with a 64K address space, it can run in 24-bit mode with a 16MB address space, and is also capable of running in a hybrid mode with a mixture of 24-bit and 8-bit code.
 
 The eZ80F92 integrates a number of standard peripherals, including a UART, and hardware timers.
 
-There is a second CPU dedicated to handling video, sound, and keyboard, an ESP32. This co-processor is linked to the eZ80F92 via a UART, and acts as a graphics terminal.
+There is a second CPU dedicated to handling video, sound, and keyboard, an ESP32-Pico-D4. This co-processor is linked to the eZ80F92 via a UART (a high speed serial communications link), and acts as a graphics terminal.
 
 ## What is the Quark Firmware
 
@@ -23,6 +27,17 @@ The Quark firmware is the official operating system for the Agon Light. It consi
 * [MOS](MOS.md): Machine Operating System
 * [VDP](VDP.md): Visual Display Processor
 * [BBC BASIC for Agon](BBC-BASIC-for-Agon.md): A specially adapted port of R.T.Russell's excellent BASIC interpreter
+
+## How can I find out more?
+
+The following documents provide some more information
+
+* [Agon Platform theory of operation](Theory-of-operation.md)
+* [External documentation](External-Documentation.md)
+* [Using GPIO](GPIO.md)
+* [The Agon Projects github](Projects.md)
+* [Third party projects](Third-Party-Projects.md)
+* [FAQ](FAQ.md)
 
 ## Where can I buy one?
 
@@ -34,5 +49,3 @@ The Quark firmware is the official operating system for the Agon Light. It consi
 - [Agon Light Australia](https://agonlight.au)
 - [Agon Light Store (UK)](http://agon-light.store)
 - [Agon Console8 from Heber (UK)](https://shop.heber.co.uk/agon-console8/)
-
-Please note that the Olimex version (Agon Light 2) is lightly customised, yet still fully compatible with the original Agon Light.

--- a/Theory-of-operation.md
+++ b/Theory-of-operation.md
@@ -1,0 +1,83 @@
+# Understanding the Agon Light computer platform
+
+The Agon Light, and its variants, is a retro-style computer platform that is designed to be inexpensive and easy to manufacture, using commonly available parts.
+
+The platform is designed to be easy to understand, and easy to program.  It is designed to be a platform that is suitable for learning about computers, and learning about programming.
+
+Please note this is a preliminary guide to the Agon Light platform, and is subject to change.  The Agon Light platform is still under development, and this guide is still being written.
+
+
+## The Agon Light hardware
+
+### The main processor
+
+The primary processor on which you run programs is an eZ80.  This is a microcontroller based on the Zilog Z80 processor, which was used in many computers and arcade machines in the 1970s and 1980s.  The eZ80 is a modern version of the Z80, with a few enhancements.  It has attached to it 512KB of RAM, which is considerably more than the 64KB that was common in the 1980s.  Also attached to the eZ80 chip is an SD card interface, allowing an SD card to be used for storage.
+
+The eZ80 was chosen as the main processor of the Agon Light because of its historic ubiquity, and because it is still manufactured today.  It is a relatively simple processor, and is easy to understand and program.
+
+### The video display processor, or VDP
+
+Whilst the eZ80 is manufactured today, none of the video chips that were used in computers of the 1970s and 1980s are still manufactured, so for video output a different solution is needed.  To solve this problem the Agon Light uses a separate video processor, which we call the VDP, the Video Display Processor.  This chip is responsible for sound and video output, and also keyboard and mouse input.  Technically, this is an ESP32-Pico-D4 chip, which has attached to it an 8MB RAM chip which is used for screen memory and storing bitmaps and sound samples.
+
+The exact technical details of the VDP however for most programmers is not important - in the Agon platform, from a software perspective, the VDP is designed to be used via a simple API, with the details of how it works abstracted away.  Indeed, when using an emulator of the Agon Light, the VDP chip is not emulated at all, and the emulator instead runs a compiled version of the VDP firmware using the host computer's video and audio hardware.
+
+
+Effectively, the design of the Agon Light is that of two computers in one.  The eZ80 is the computer that is used to run programs, and the VDP is a computer that draws the screen and plays sound.  The eZ80 and the VDP communicate with each other using a high speed serial interface.
+
+
+Some other retro-inspired computers take a different approach to solving the video output problem.  Often this involves making use of an FPGA chip, which is a chip that can be programmed to behave like any other chip.  This is a very flexible solution, but it is also very expensive.  The Agon Light takes a different approach, using a separate video processor chip, which is much cheaper than an FPGA.
+
+
+The use of what is effectively a separate computer for the VDP in the Agon platform creates a significant architectural difference to many classic home computers of the 8-bit, 16-bit and early 32-bit era.  Those classic computers would usually use a shared area of memory that the main processor and the video processor would both have access to.  This shared memory would be used to store the screen memory, and the main processor would write to this memory to update the screen.  This is not the case with the Agon platform.  The eZ80 and the VDP have no shared memory, and the VDP has no access to the eZ80's RAM.  This means that the VDP cannot read the screen memory directly, and the eZ80 cannot write directly to the screen memory.  Instead, the VDP has to be sent commands to draw things to the screen, and the eZ80 has to be sent commands to read things from the screen.  This is a significant difference to many classic computers, and is something that programmers need to be aware of when writing programs for the Agon platform.
+
+
+## The Agon software platform
+
+From a software perspective, a significant inspiration for the Agon Light was the BBC Micro, a popular computer in the UK from the 1980s designed and built by Acorn Computers Ltd..  (Acorn went on to design the ARM processor, which is now the most commonly used processor design in the world.)  The BBC Micro was part of the BBC's Computer Literacy Project, which was a project to introduce computers to the UK population with an emphasis on education.  The BBC Micro was designed to be easy to use, and to be used in schools by children.
+
+There are several significant differences between the Agon Light and the BBC Micro, but the two most important ones are the main processor, and the video system.  A BBC Micro was based on the 6502 CPU, which was a competitor to the Z80.  The 6502 was a simpler processor than the Z80, and was cheaper to manufacture, and given the relative simplicity often significantly faster than the Z80.  The 6502 was used in many popular computers of the 1970s and 1980s, including the Apple II, the Commodore 64, and the Atari 2600.  The Z80 was used in many other popular computers of the 1970s and 1980s, including the Sinclair ZX80, the Sinclair ZX81, the Sinclair Spectrum, the Amstrad CPC, and the MSX.  The BBC Micro however was designed from the ground up to be a computer capable of having multiple processors, and the first second processor option available for the computer was the Z80.  A version of BBC BASIC was produced for Acorn's Z80 second processor, and this is the version of BBC BASIC that the Agon Light is directly based on.
+
+
+### BBC BASIC
+
+An important part of the BBC Micro was BBC BASIC, a well respected version of the BASIC programming language.  Compared to other versions of BASIC, BBC BASIC was very powerful since it included many advanced features, such as procedures, functions, and recursion.  It also included many commands for graphics and sound, which made it easy to write games and other programs that used graphics and sound.
+
+The original version of BBC BASIC for the 6502 processor was written by Sophie Wilson of Acorn.  The version of BBC BASIC for the Z80 was written by R.T.Russell, and was based on the original version by Sophie Wilson.  The version of BBC BASIC for the Agon Light is directly based on R.T.Russell's version, and is largely compatible with the BBC Micro version.
+
+BBC BASIC has an inbuilt assembler, which allows for machine code to be embedded within BASIC programs.  This is a very powerful feature, and allows for programs to be written that make use of the full power of the processor.  Machine code can run very many times faster than interpreted BASIC.  It should be noted that the Z80 version of BASIC as used on the Agon platform has an assembler for the Z80 built in, whereas the original 6502 version of BASIC for the BBC Micro included an assembler for the 6502 processor.  Programs written for the BBC Micro that include assembler code will therefore not run on the Agon Light without rewriting those assembler routines.
+
+#### BBC BASIC ADL version
+
+There is now a newer version of BBC BASIC for the Agon platform known as the "ADL version".  The original Z80 version of BBC BASIC was restricted to work within 64KB of RAM.  This limitation was due to the fact that the Z80 processor only has 16 address lines (also referred to as a 16-bit address bus), so technically it can only address 64KB of RAM.
+
+The newer eZ80 CPU used in the Agon Light has a 24-bit address bus, which means that it can potentially address up to 16MB of RAM.  Agon Light machines come with 512KB of RAM attached to the eZ80 CPU.
+
+To allow programs to make use of this extra RAM, and some other new facilities, the eZ80 has extensions known as "ADL mode".  This mode extends some processor registers to 24 bits, and allows for the use of the extra RAM.  The ADL version of BBC BASIC is designed to make use of this extra RAM, and to allow for programs to be written that make use of more than 64KB of RAM.
+
+The ADL version of BBC BASIC also includes modifications to the assembler to allow for the use of newer ADL machine code instructions.  This means that programs written for the ADL version of BBC BASIC may not run on the original Z80 version of BBC BASIC.
+
+
+### VDU commands, and the VDP
+
+The other significant difference between the Agon Light and the BBC Micro is the video system.  As video output is handled by a separate processor, and there is no shared memory between the two processors within an Agon Light, the design of the Agon system does not allow for the video system to work in the same kind of manner as a BBC Micro.  From a software perspective, however, the Agon Light is designed to be as similar as possible to the BBC Micro, and the video system is designed to be as similar as possible to the BBC Micro video system.  This means that many programs written for the BBC Micro can be ported to the Agon Light with minimal changes.
+
+Using BASIC on a BBC Micro, the primary way to draw things to the screen was via simple keywords such as `PRINT`, `MOVE`, `DRAW`, `PLOT`, `COLOUR` (etc.) and most importantly `VDU`.  It is the `VDU` keyword that sent commands to the video system.  Effectively _all_ of the other keywords that drew onto the screen (or changed drawing settings) are just shorthand for `VDU` commands.
+
+The same is true on the Agon Light.  The Agon's VDP processor has been written to understand the same `VDU` commands as the BBC Micro, and so the same keywords that draw things to the screen on a BBC Micro will also draw things to the screen on an Agon Light.  This means that many programs written in BBC BASIC for the BBC Micro can be ported to the Agon Light with minimal changes.
+
+The Agon Light also includes a number of additional `VDU` commands that are not present on the BBC Micro, which allow for more advanced graphics and sound effects.  These commands are documented in the [VDP](VDP.md) section of this documentation.
+
+
+The nature of the MOS/VDP split on the Agon platform carries with it some limitations that you should be aware of.
+
+The nature of the VDP is that it is, essentially, a stream processor.  It accepts a stream of data from the eZ80, and interprets that as a stream of commands and data.  In regular use, there is no command to indicate the beginning of a command stream, and no command to indicate the end of a command stream.  The VDU commands that the VDP interprets are of a variable length, ranging from a single byte to potentially over 64kb.  A single `VDU` statement in BASIC could be a complete command from the perspective of the VDP, or it could be the first part of a command that is continued in the next `VDU` statement.  For commands that are intended to send across a large amount of data, such as a bitmap or a sound sample, the data is typically sent using a series of `VDU` statements, each of which is a part of the same command.
+
+Care must therefore be taken to ensure that the VDP is sent complete commands, and that commands are not interleaved.  For instance, it may be tempting when transfering over a sound sample to use `PRINT` or `DRAW` statements to show progress.  This will not work, because the VDP will interpret the `PRINT` or `DRAW` statements (which will have been translated into a raw VDU byte command stream) as part of the sound sample data.
+
+To solve this issue, the VDP provides a [Buffered Commands API](VDP---Buffered-Commands-API.md).  This allows for data to be sent to the VDP in discrete chunks, sent to one of over 65000 buffers.  Once all of the data has been sent, a command can be sent to the VDP to make use of the data in the buffer, whether that is to use the buffer as a sound sample, a bitmap, or a sequence of VDU commands.  So to print a progress bar whilst sending a sound sample, you would send the sound sample data to a buffer a chunk at a time using the Buffered Commands API "add block" command, and after each chunk use drawing commands to update the progress bar.  Once all of the sound sample data has been sent, you would then send a command to the VDP to identify that data as a sound sample, and/or use other commands to play that sample.
+
+
+
+
+
+

--- a/Third-Party-Projects.md
+++ b/Third-Party-Projects.md
@@ -1,10 +1,19 @@
 # Third Party Projects
 
+Please note that this list is _far_ from exhaustive. If you have a project that you would like to add to this list, please submit a pull request.
+
+
+## Popup MOS
+
+https://github.com/tomm/popup-mos
+
+A batteries-included SDCard template for Agon Light / Agon Light 2 / Console8
+
 ## Flash Upgrader
 
 https://github.com/envenomator/agon-flash
 
-A utility to flash a MOS image to the eZ80F92 Flash without a ZDS USB cable
+A utility to flash a MOS image to the eZ80F92 Flash without a ZDS USB cable, and to update the VDP firmware.
 
 ## Hex Loader
 

--- a/Updating-Firmware.md
+++ b/Updating-Firmware.md
@@ -1,5 +1,7 @@
 ## How to upgrade from Quark 1.02 to 1.03 using the Agon-Flash utility
 
+NB this document is very outdated and needs to be rewritten.  If you have found your way here, please be aware that the instructions below are no longer correct, or the best way to udpate your Agon machine.
+
 Instructions kindly collated by Tim Delmare
 
 ### Disclaimer

--- a/VDP.md
+++ b/VDP.md
@@ -4,9 +4,10 @@ The VDP is the Agon's Visual Display Processor. It is responsible for:
 
 * Video output via the VGA connector
 * Audio output via the built-in buzzer and audio jack
-* Keyboard input via the PS/2 connector
+* Keyboard input via a PS/2 connector
+* Mouse input via a PS/2 connector (on the Agon Console8, or with an adapter on the Agon Light)
 
-It runs on the ESP32 co-processor and uses the FabGL library to support those functions.
+It runs on the ESP32-Pico-D4 co-processor and uses a fork of the FabGL library (known as vdp-gl) to support those functions.
 
 At a higher level, its input is a byte stream from the eZ80F92 main CPU over an internal high-speed UART connection @ 1,152,000 baud (384,000 baud for versions of MOS/VDP prior to 1.03). This stream contains a mixture of text and control characters. These control characters are mapped to the BBC BASIC VDU control characters, a choice made as BBC BASIC for Agon is the pre-installed programming language of Agon.
 
@@ -32,53 +33,75 @@ Example:
 
 ## VDU Character Sequences
 
-The VDU command is a work-in-progress with a handful of mappings implemented.
+The aim is that the Agon's VDP should be as compatible as practical with the BBC Micro's VDU command, as well as the VDU commands supported by later versions of Acorn and R.T.Russell's BBC BASICs.  Where necessary, some extensions have been added to help facilitate the Agon's unique features and architecture.
 
-- `VDU 8`: Cursor left
-- `VDU 9`: Cursor right
-- `VDU 10`: Cursor down
-- `VDU 11`: Cursor up
-- `VDU 12`: CLS
+The following VDU sequences are supported:
+
+- `VDU 0`: Null (no operation)
+- `VDU 4`: Write text at text cursor
+- `VDU 5`: Write text at graphics cursor
+- `VDU 7`: Make a short beep (BEL)
+- `VDU 8`: Move cursor back one character
+- `VDU 9`: Move cursor forward one character
+- `VDU 10`: Move cursor down one line
+- `VDU 11`: Move cursor up one line
+- `VDU 12`: Clear text area (`CLS`)
 - `VDU 13`: Carriage return
 - `VDU 14`: Page mode ON (VDP 1.03 or greater)
 - `VDU 15`: Page mode OFF (VDP 1.03 or greater)
-- `VDU 16`: CLG
-- `VDU 17 colour`: COLOUR colour
-- `VDU 18, mode, colour`: GCOL mode, colour
-- `VDU 19, l, p, r, g, b`: COLOUR l, p / COLOUR l, r, g, b
-- `VDU 22, n`: Mode n
-- `VDU 23, n`: UDG / System Commands
+- `VDU 16`: Clear graphics area (`CLG`)
+- `VDU 17, colour`: Define text colour (`COLOUR`)
+- `VDU 18, mode, colour`: Define graphics colour (`GCOL mode, colour`)
+- `VDU 19, l, p, r, g, b`: Define logical colour (`COLOUR l, p` / `COLOUR l, r, g, b`)
+- `VDU 22, n`: Select screen mode (`MODE n`)
+- `VDU 23, n`: Re-program display character / System Commands
 - `VDU 24, left; bottom; right; top;`: Set graphics viewport (VDP 1.04 or greater)
 - `VDU 25, mode, x; y;`: PLOT mode, x, y
 - `VDU 26`: Reset graphics and text viewports (VDP 1.04 or greater)
+- `VDU 27, char`: Output character to screen (Agon Console8 VDP 2.3.0 or later)
 - `VDU 28, left, bottom, right, top`: Set text viewport (VDP 1.04 or greater)
 - `VDU 29, x; y;`: Graphics origin
 - `VDU 30`: Home cursor
 - `VDU 31, x, y`: TAB(x, y)
 - `VDU 127`: Backspace
 
-All other characters are sent to the screen as ASCII, unaltered.
+All other characters, i.e. those in the range of 32 to 126 and 128 to 255, are sent to the screen as ASCII, unaltered.
+
+Any VDU command that is not recognised (such as `VDU 1`) will be ignored.
+
 
 ## VDU 23, 0: VDP commands
 
 VDU 23, 0 is reserved for commands sent to the VDP
 
+- `VDU 23, 0, &80, n`: General poll, which echoes back `n` to MOS (see [Serial Protocol](#serial-protocol))
 - `VDU 23, 0, &81, n`: Set the keyboard locale (0=UK, 1=US, etc) 
 - `VDU 23, 0, &82`: Request text cursor position
 - `VDU 23, 0, &83, x; y;`: Get ASCII code of character at character position x, y
 - `VDU 23, 0, &84, x; y;`: Get colour of pixel at pixel position x, y
-- `VDU 23, 0, &85, channel, command, <args>`: Send a command to the [VDP Enhanced Audio API](VDP---Enhanced-Audio-API.md)
-- `VDU 23, 0, &86`: Fetch the screen dimensions 
-- `VDU 23, 0, &87`: RTC control (Requires MOS 1.03 or above)
-- `VDU 23, 0, &88, delay; rate; led`: Keyboard Control (Requires MOS 1.03 or above)
-- `VDU 23, 0, &89, command, [<args>]`: Mouse control
-- `VDU 23, 0, &A0, bufferId, command, <args>`: Send a command to the [VDP Buffered Commands API](VDP---Buffered-Commands-API.md)
-- `VDU 23, 0, &C0, n`: Turn logical screen scaling on and off, where 1=on and 0=off (Requires MOS 1.03 or above)
-- `VDU 23, 0, &C1, n`: Switch legacy modes on or off
-- `VDU 23, 0, &C3`: Flip the screen buffer (double-buffered modes only) or wait for VSYNC (all modes)
-- `VDU 23, 0, &FF`: Switch to terminal mode for CP/M (This will disable keyboard entry in BBC BASIC/MOS)
+- `VDU 23, 0, &85, channel, command, <args>`: Send a command to the [VDP Enhanced Audio API](VDP---Enhanced-Audio-API.md) **
+- `VDU 23, 0, &86`: Fetch the screen dimensions
+- `VDU 23, 0, &87`: RTC control *
+- `VDU 23, 0, &88, delay; rate; led`: Keyboard Control *
+- `VDU 23, 0, &89, command, [<args>]`: Mouse control **
+- `VDU 23, 0, &90, n, b1, b2, b3, b4, b5, b6, b7, b8`: Redefine character n (0-255) with 8 bytes of data §
+- `VDU 23, 0, &91`: Reset all characters to original definition §
+- `VDU 23, 0, &92, char, bitmapId;`: Map character char to display bitmapId §§
+- `VDU 23, 0, &94, n`: Read colour palette entry n (returns a pixel colour data packet) §§
+- `VDU 23, 0, &A0, bufferId, command, <args>`: Send a command to the [VDP Buffered Commands API](VDP---Buffered-Commands-API.md) **
+- `VDU 23, 0, &A1`: Update VDP (for exclusive use of the agon-flash tool) **
+- `VDU 23, 0, &C0, n`: Turn logical screen scaling on and off, where 1=on and 0=off *
+- `VDU 23, 0, &C1, n`: Switch legacy modes on or off **
+- `VDU 23, 0, &C3`: Flip the screen buffer (double-buffered modes only) or wait for VSYNC (all modes) **
+- `VDU 23, 0, &FF`: Switch to or resume terminal mode for CP/M (This will disable keyboard entry in BBC BASIC/MOS)
 
-Commands between &82 and &89 will return their data back to the eZ80 via the serial protocol
+ \* Requires VDP 1.03 or above<br>
+ \** Requires VDP 1.04 or above<br>
+ § Requires Console8 VDP 2.3.0 or above<br>
+ §§ Requires Console8 VDP 2.4.0 or above
+ 
+
+Commands between &82 and &89 will return their data back to the eZ80 via the [serial protocol](#serial-protocol).
 
 NB:
 
@@ -88,6 +111,22 @@ NB:
 
 - `VDU 23, 0, 7, 0`: Read the RTC
 - `VDU 23, 0, 7, 1, y, m, d, h, m, s`: Set the RTC
+
+## Mouse control
+
+Commands beginning with `VDU 23, 0, &89` are reserved for mouse control, and are implemented from VDP 1.04 onwards.
+
+- `VDU 23, 0, &89, 0`: Enable the mouse
+- `VDU 23, 0, &89, 1`: Disable the mouse
+- `VDU 23, 0, &89, 2`: Reset the mouse
+- `VDU 23, 0, &89, 3, cursorId;`: Set mouse cursor
+- `VDU 23, 0, &89, 4, x; y;`: Set mouse cursor position
+- `VDU 23, 0, &89, 5, x1; y1; x2; y2;`: Reserved (Set mouse area - not yet implemented)
+- `VDU 23, 0, &89, 6, sampleRate;`: Set mouse sample rate
+- `VDU 23, 0, &89, 7, resolution;`: Set mouse resolution
+- `VDU 23, 0, &89, 8, scaling`: Set mouse scaling
+- `VDU 23, 0, &89, 9, acceleration;`: Set mouse acceleration
+- `VDU 23, 0, &89, 10, wheelAcceleration; wheelAccHighByte`: Set mouse wheel acceleration (accepts a 24-bit value)
 
 ## VDU 23, 1: Cursor display
 
@@ -147,6 +186,9 @@ Data sent from the VDP to the eZ80's UART0 is sent as a packet in the following 
 
 Words are 16 bit, and sent in little-endian format
 
+In general, as a programmer using an Agon you should not need to worry about any of these packets, as they are handled by MOS.  On receipt of one of these packets MOS sets system variables accordingly.  It will set a bit in the VDPProtocol status byte, and then whichever other system variables are relevant to the packet received.
+
+
 Packets:
 
 - `0x00`: General Poll
@@ -154,11 +196,11 @@ Packets:
 - `0x02, x, y`: Cursor position
 - `0x03, char`: Character read from screen
 - `0x04, r, g, b, index`: Pixel colour read from screen
-- `0x05, channel, success`: Audio play note acknowledgement
-- `0x06, width, height, cols, rows, colours`: Screen dimensions - width and height are words
+- `0x05, channel, status`: Audio command status (see [VDP Enhanced Audio API](VDP---Enhanced-Audio-API.md))
+- `0x06, width; height; cols, rows, colours`: Screen dimensions - width and height are words
 - `0x07, year, month, day, dayOfYear, dayOfWeek, hour, minute, second`: RTC data
 - `0x08, delay, rate, led`: Keyboard status - delay and rate are words
-- `0x09, x, y, buttons, wheelDelta, deltaX, deltaY`: Mouse status - x, y, deltaX and deltaY are words
+- `0x09, x; y; buttons, wheelDelta, deltaX; deltaY;`: Mouse status - x, y, deltaX and deltaY are words
 
 ## Keyboard
 

--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,9 @@ include:
   - MOS-API.md
   - MOS.md
   - Projects.md
+  - Theory-of-operation.md
   - Third-Party-Projects.md
   - Updating-Firmware.md
+  - VDP---Buffered-commands-API.md
   - VDP---Enhanced-Audio-API.md
   - VDP.md


### PR DESCRIPTION
Fills in some gaps in documentation

this includes documentation for features that have been added recently, as well as some that slipped thru

there’s some reworking of the buffered commands API docs to make their use slightly clearer

also expose more of the documentation we have