### PR TITLE
Split up the VDP documentation, and expand

### DIFF
--- a/VDP---Bitmaps-API.md
+++ b/VDP---Bitmaps-API.md
@@ -1,0 +1,169 @@
+# VDU 23, 27: Bitmaps, sprites, and mouse cursor
+
+VDU 23, 27 is reserved for the bitmap, sprite, and mouse cursor functionality.
+
+As of VDP 1.04, the bitmap system is integrated with the (Buffered Commands API)[VDP---Buffered-Commands-API.md].  Bitmap data is stored in buffers, and can be manipulated using the Buffered Commands API on the VDP.
+
+
+## Bitmaps
+
+The bitmap system we have on the Agon uses commands that are inspired by Acorn's Graphics eXtension ROM (GXR) system.  Some mistakes were made in the original interpretation of the GXR commands, and so until the Console8 VDP 2.2.0 release it was not possible to use code written for GXR on the Agon.
+
+Acorn only actually had two VDU commands for what it called "sprites", which in the Agon we consider to be "bitmaps".  The first command was used to select a bitmap (so that it may later be used with an appropriate PLOT command), and the second was to define a bitmap from an area of screen.
+
+The approach taken on Agon (initially at least) was to redefine the "define bitmap from screen" command to instead allow the uploading of a binary bitmap image.  In doing so, the parameters of the command changed, and the bitmap identifier was lost from the command parameters.  Instead, on the Agon, you need to always perform a "select bitmap" command before any other bitmap commands to set the bitmap being used.  Additionally on the Agon, prior to Console8 VDP 2.2.0, plotting bitmaps could only be performed with a custom command, and not with the standard `PLOT` commands.
+
+As of Console8 VDP 2.2.0, it is now possible to use Acorn GXR style "sprite" code on an Agon.  The `PLOT` code for drawing bitmaps is now supported, and bitmap command 1 can now be used to capture screen data into a bitmap identically to the GXR.
+
+In addition to GXRs two commands, the Agon VDP has several other commands for managing bitmaps, and additional commands to manage "sprites".
+
+As has been noted above, bitmap data is stored in buffers.  Acorn's original API design only allows for a maximum of 255 bitmaps, as they used an 8-bit ID, however buffers are identified with a 16-bit identifier.  This means that the Agon VDP can support a much larger number of bitmaps, in theory up to 65534 of them.  To allow access to these additional bitmaps, the Agon VDP several additional commands working with bitmaps using 16-bit IDs.  Those 16-bit IDs directly correspond to the IDs of the buffers in which the bitmpas are stored.  Bitmaps with 8-bit IDs are automatically mapped onto buffer IDs in the range 64000-64255.
+
+In general, commands to manage bitmaps using 16-bit IDs are numbered 32 higher than the equivalent command using an 8-bit ID (32 is `&20` in hexadecimal).  For instance, the command to select a bitmap with an 8-bit ID is `VDU 23, 27, 0, n`, whereas the command to select a bitmap with a 16-bit ID is `VDU 23, 27, &20, bufferId;`.
+
+Storing bitmaps in buffers allows for their data to be manipulated using the buffered commands API.  This can, for instance, allow for the colours of bitmaps to be changed, or for a bitmap to be mirrored, or split into multiple bitmaps.
+
+\* Commands marked with an asterisk are only available in VDP 2.2.0 or later.
+
+The commands to manage bitmaps are as follows:
+
+### `VDU 23, 27, 0, n`: Select bitmap n
+
+This selects the bitmap with the given 8-bit ID as being the currently "active" bitmap for subsequent bitmap commands.
+
+As noted above, bitmaps with 8-bit IDs are stored in buffers with an ID of 64000+`n`.
+
+
+### `VDU 23, 27, 1, w; h; b1, b2 ... bn`: Load colour bitmap data into current bitmap
+
+This command is used to load bitmap data directly into the currently selected bitmap.
+
+Before you can load bitmap data into a bitmap, you must first select the bitmap using `VDU 23, 27, 0, n`, where `n` is the 8-bit ID of the bitmap to be loaded, or using `VDU 23, 27, &20, bufferId;` using a 16-bit buffer ID.
+
+The bitmap data is given as a series of bytes as part of the command in RGBA8888 format, meaning that each pixel is represented by four bytes, one each for the red, green, blue, and alpha components of the pixel.  Each component value is in the range of 0-255.  The bytes are given in row-major order, starting at the top left of the bitmap, and working across the rows, and then down the columns.
+
+The width and height of the bitmap must be given in pixels, and must match the number of bytes given in the data.  If the width and height do not match the data then the command will fail.
+
+It should be noted that whilst the image format supported by this command is for full 24-bit colour images with 256 levels of transparency (alpha) per pixel, the Agon hardware is only capable of displaying 2-bits per colour channel.  Data loaded via this command remains in RGBA8888 format on the VDP, but is converted on the fly when the bitmap is drawn to the screen.
+
+(As RGBA8888 is a very wasteful format, given the hardware limitations, other options are now available.  Loading bitmaps with this command can take a long time, and it is not possible to intersperse other commands, such as showing progress on-screen, whilst the data is being sent.  There are however alternative ways of managing the data which avoids these issues.  Please see the section on "Using buffers for bitmaps" in the [Buffered Commands API](VDP---Buffered-Commands-API.md) document for more information.)
+
+### `VDU 23, 27, 1, n, 0, 0;`: Capture screen data into bitmap n *
+
+This command, added in Agon Console8 VDP 2.2.0, is compatible with the Acorn GXR command of the same number.  It captures the screen data into the bitmap with the given 8-bit ID.
+
+This version of the `VDU 23, 27, 1` command differs from the one documented before in that you do not need to explicitly select a bitmap before capturing screen data into it.  The bitmap ID is passed as a parameter to this version of the command.
+
+As you may have noticed, this command does not include any dimensions for the bitmap.  Those are set via the graphics system, taking the last two graphics cursor positions to define the bitmap rectangle.  Any `PLOT`, or `VDU 25`, style command will push the graphics cursor position - typically "move" style plot commands are used to define the rectangle.
+
+To be clear, this command should be performed _after_ two "move" style PLOT commands.
+
+If a bitmap with the given ID already exists then it will be overwritten, and similarly if a buffer was already defined with the ID 64000+`n` then that will be overwritten too.
+
+Bitmap data captured using this command will be stored in "native" format, which is RGB222, with no alpha channel, one byte per pixel.
+
+### `VDU 23, 27, 2, w; h; col1; col2;`: Create a solid colour rectangular bitmap 
+
+Creates a new bitmap in RGBA8888 format with the given width and height, and fills it with a solid colour.  The colour is given as two 16-bit numbers, col1 and col2, which are combined to form a 32-bit number in RGBA colour range.
+
+The bitmap is created in the buffer with the ID 64000+`n`, where `n` is the 8-bit ID given in the command.
+
+### `VDU 23, 27, 3, x; y;`: Draw current bitmap on screen at pixel position x, y
+
+Prior to Agon Console8 VDP 2.2.0, this was the only way to draw a bitmap on-screen.
+
+Before this command can be used, a bitmap must be selected using `VDU 23, 27, 0, n`, where `n` is the 8-bit ID of the bitmap to be drawn, or using `VDU 23, 27, &20, bufferId;` using a 16-bit buffer ID.
+
+The x and y parameters give the pixel position on the screen at which the top left corner of the bitmap will be drawn.  This is in contrast to `PLOT` commands which will (by default) use OS Coordinates, where the origin is at the bottom left of the screen and the screen is always considered to have the dimensions 1280x1024.
+
+### `VDU 23, 27, &20, bufferId;`: Select bitmap using a 16-bit buffer ID *
+
+This command is essentially identical to `VDU 23, 27, 0, n`, however it uses a 16-bit buffer ID instead of an 8-bit bitmap ID.
+
+### `VDU 23, 27, &21, w; h; format`: Create bitmap from selected buffer *
+
+This command creates a new bitmap from the data in the currently selected buffer.
+
+Whilst bitmap data can be loaded into a buffer at any time, before that data can drawn on-screen it must be converted into a bitmap.  The VDP needs to understand the width and height of the bitmap, and the format of the data.  This command performs that conversion.
+
+Valid values for the format parameter are:
+
+| Value | Meaning |
+| ----- | ------- |
+| 0 | RGBA8888 (4-bytes per pixel) |
+| 1 | RGBA2222 (1-bytes per pixel) |
+| 2 | Mono (1-bit per pixel) |
+
+Mono bitmaps can be of any width, but their data must be sent using a whole number of bytes per row.  Mono bitmaps are also required to have a colour, and will use the currently selected graphics foreground colour.  If you wish to use a different colour then you must change the graphics foreground colour before creating the bitmap.
+
+As with `VDU 23, 27, 1, w; h; b1, b2...bn`, the width and height of the bitmap must be given in pixels, and must match the number of bytes given in the data.  If the width and height do not match the data then the command will fail.
+
+Prior to the Console8 VDP 2.2.0 release, mono bitmaps were not supported.
+
+### `VDU 23, 27, &21, bitmapId; 0;`
+
+This command captures a bitmap from the screen into the buffer with the given 16-bit buffer ID.  It works the same as `VDU 23, 27, 1, n, 0, 0;`, but using a 16-bit buffer ID instead of an 8-bit bitmap ID.
+
+Support for this command was added in VDP 2.2.0.
+
+
+## Sprites
+
+The Sprites system on the Agon VDP is an extension to the bitmap system.  They are not true "hardware sprites" as one might find on some 8-bit machines or consoles.  They are best thought of as "automatically drawn bitmaps".
+
+Technically the VDP can support up to 256 sprites.  They must be defined contiguously, and so the first sprite is sprite 0.  (In contrast, bitmaps can have any ID from 0 to 65534.)  Once a selection of sprites have been defined, you can activate them using the `VDU 23, 27, 7, n` command, where `n` is the number of sprites to activate.  This will activate the first `n` sprites, starting with sprite 0.  All sprites from 0 to n-1 must be defined.
+
+A single sprite can have multiple "frames", referring to different bitmaps.  (These bitmaps do not need to be the same size.)  This allows a sprite to include an animation sequence, which can be stepped through one frame at a time, or picked in any order.
+
+An "active" sprite can be hidden, so it will stop being drawn, and then later shown again.
+
+Moving sprites around the screen is done by changing the position of the sprite.  This can be done either by setting the absolute position of the sprite, or by moving the sprite by a given number of pixels.  (Sprites are positioned using pixel coordinates, and not by the logical OS coordinate system.)  In the current sprite system, sprites will not update their position on-screen until either another drawing operation is performed or an explicit `VDU 23, 27, 15` command is performed.
+
+Here are the sprite commands:
+
+- `VDU 23, 27, 4, n`: Select sprite n
+- `VDU 23, 27, 5`: Clear frames in current sprite
+- `VDU 23, 27, 6, n`: Add bitmap n as a frame to current sprite (where bitmap's buffer ID is 64000+`n`)
+- `VDU 23, 27, 7, n`: Activate n sprites
+- `VDU 23, 27, 8`: Select next frame of current sprite
+- `VDU 23, 27, 9`: Select previous frame of current sprite
+- `VDU 23, 27, 10, n`: Select the nth frame of current sprite
+- `VDU 23, 27, 11`: Show current sprite
+- `VDU 23, 27, 12`: Hide current sprite
+- `VDU 23, 27, 13, x; y;`: Move current sprite to pixel position x, y
+- `VDU 23, 27, 14, x; y;`: Move current sprite by x, y pixels
+- `VDU 23, 27, 15`: Update the sprites in the GPU
+- `VDU 23, 27, 16`: Reset bitmaps and sprites and clear all data
+- `VDU 23, 27, 17`: Reset sprites (only) and clear all data
+- `VDU 23, 27, &26, n;`: Add bitmap n as a frame to current sprite using a 16-bit buffer ID
+
+### Notes on sprites
+
+This advice is valid up to and including the Agon Console8 VDP 2.5.0 release.  In the future this may change.
+
+The nature of how sprites are currently supported in the Agon VDP means that performance is not as good as it could be, and so they should be used sparingly.  If you have too many sprites on-screen then you may notice that some sprites may flicker, especially if they are positioned closer to the top of the screen.  Sprites are currently always drawn in order, so those with lower IDs will flicker less than those with higher IDs.
+
+Performance of the Agon emulator differs significantly from real hardware, owing to how the VDP system is emulated.  You will be able to have more sprites on-screen on the emulator than you will on real hardware.
+
+Technically, sprites are implemented as "automatically drawn bitmaps".  When a sprite is drawn on-screen, a copy of the area of screen that it covers is made, and then the sprite bitmap is drawn over that screen area.  (Sprite bitmaps can be transparent, and the background will show through.)  When a sprite is hidden, the area of screen that it covered is copied back onto the screen.  When you have a lot of sprites, this can mean that a lot of screen data is being copied around.
+
+Owing to inefficiencies in how sprites have been implemented, _any_ operation that draws something to the screen will cause _all_ sprites to be hidden, the drawing operation performed, and then all sprites are redrawn.  (This includes, for example, the flashing of the text cursor.)  Sprites are redrawn in order by their ID at the beginning of the screen being drawn to the VGA port.  This means that if there are a lot of active sprites, those later in the list get drawn to the screen buffer later, possibly after that part of the screen has been sent out of the VGA port.  This, essentially, is the cause of the flickering.
+
+One way to reduce flickering is to try to avoid using sprites near the top of the screen.  This gives more opportunity for the sprites to be redrawn.
+
+Owing to how sprites work, it is hard to offer definitive advice on how many sprites you can use.  The size of sprites you are using will also be a factor.  It is best to experiment and see what works for you.
+
+Sprites also behave differently on double-buffered screen modes.  On those modes sprites are never "hidden" and are instead drawn to screen before a buffer swap.  This means they tend not to flicker, but care needs to be taken to ensure that the screen is properly redrawn.
+
+For optimal graphical performance, it is currently best to avoid using sprites, and instead use the bitmap system directly.  Using a small number of sprites can be a reasonable compromise.
+
+
+## Mouse cursor
+
+### `VDU 23, 27, &40, hotX, hotY`: Setup a mouse cursor
+
+Sets up a new mouse cursor using the currently selected bitmap, with a hotspot at hotX, hotY.
+
+Once a mouse cursor has been set up in this way, it can be selected for display using `VDU 23, 0, &89, 3, bitmapId;`.  Please note that this is a 16-bit ID, therefore if a bitmap had been selected using an 8-bit identifier you will need to add 64000 to the ID to get the 16-bit ID.
+
+Care should be taken to avoid using bitmapIds from 0-18, as those conflict with existing cursor Ids.

--- a/VDP---PLOT-Commands.md
+++ b/VDP---PLOT-Commands.md
@@ -1,0 +1,73 @@
+# VDU 25: PLOT commands
+
+The Agon VDP system supports a number of `PLOT` commands via `VDU 25`, which are used to draw lines, circles, and other shapes on the screen.  The command set is inherited from Acorn's BBC Micro, plus Acorn's Graphics eXtension ROM (GXR).
+
+Support for PLOT commands has grown over time, but is still only a subset of those available on a BBC Micro with a GXR ROM.
+
+Prior to VDP 1.04 the PLOT command support was very limited, did not support relative positioning, and had buggy and incorrect interpretations of some of the PLOT codes.  As of VDP 1.04 the PLOT command support has been greatly improved, and is now much more compatible with the BBC Micro and GXR ROM.
+
+The most significant bug was the mis-interpretation of several "move" commands to instead be "draw".  As a result, some programs written for earlier versions of the VDP firmware may no longer work correctly.  Fixing these programs however is usually very straightforward and usually just involves changing the PLOT code used.
+
+PLOT commands are essentially split into a drawing operation, and a mode that controls how the drawing operation is performed.  There are 8 different modes for each operation.  The command byte is effectively split into two parts where the lower 3 bits define the mode, and the upper 5 bits define the drawing operation.
+
+The complete set of PLOT codes supported by the Agon VDP follows.  For completeness, all commands from Acorn's command set are shown, including those that are not yet supported.
+
+| PLOT code | (Decimal) | Effect |
+| --------- | --------- | ------ |
+| &00-&07 | 0-7 | Solid line, includes both ends |
+| &08-&0F | 8-15 | Solid line, final point omitted |
+| &10-&17 | 16-23 | Not supported (Dot-dash line, includes both ends, pattern restarted) |
+| &18-&1F | 24-31 | Not supported (Dot-dash line, first point omitted, pattern restarted) |
+| &20-&27 | 32-39 | Solid line, first point omitted |
+| &28-&2F | 40-47 | Solid line, both points omitted |
+| &30-&37 | 48-55 | Not supported (Dot-dash line, first point omitted, pattern continued) |
+| &38-&3F | 56-63 | Not supported (Dot-dash line, both points omitted, pattern continued) |
+| &40-&47 | 64-71 | Point plot |
+| &48-&4F | 72-79 | Line fill left and right to non-background §§ |
+| &50-&57 | 80-87 | Triangle fill |
+| &58-&5F | 88-95 | Line fill right to background §§ |
+| &60-&67 | 96-103 | Rectangle fill |
+| &68-&6F | 104-111 | Line fill left and right to foreground §§ |
+| &70-&77 | 112-119 | Parallelogram fill |
+| &78-&7F | 120-127 | Line fill right to non-foreground §§ |
+| &80-&87 | 128-135 | Not supported (Flood until non-background) |
+| &88-&8F | 136-143 | Not supported (Flood until foreground) |
+| &90-&97 | 144-151 | Circle outline |
+| &98-&9F | 152-159 | Circle fill |
+| &A0-&A7 | 160-167 | Not supported (Circular arc) |
+| &A8-&AF | 168-175 | Not supported (Circular segment) |
+| &B0-&B7 | 176-183 | Not supported (Circular sector) |
+| &B8-&BF | 184-191 | Rectangle copy/move |
+| &C0-&C7 | 192-199 | Not supported (Ellipse outline) |
+| &C8-&CF | 200-207 | Not supported (Ellipse fill) |
+| &D0-&D7 | 208-215 | Not defined |
+| &D8-&DF | 216-223 | Not defined |
+| &E0-&E7 | 224-231 | Not defined |
+| &E8-&EF | 232-239 | Bitmap plot § |
+| &F0-&F7 | 240-247 | Not defined |
+| &F8-&FF | 248-255 | Not defined |
+
+§ Support added in Agon Console8 VDP 2.1.0
+§§ Support added in Agon Console8 VDP 2.2.0
+
+Within each group of eight plot codes, the effects are as follows:
+
+| Plot code | Effect |
+| --------- | ------ |
+| 0 | Move relative |
+| 1 | Plot relative in current foreground colour |
+| 2 | Not supported (Plot relative in logical inverse colour) |
+| 3 | Plot relative in current background colour |
+| 4 | Move absolute |
+| 5 | Plot absolute in current foreground colour |
+| 6 | Not supported (Plot absolute in logical inverse colour) |
+| 7 | Plot absolute in current background colour |
+
+Codes 0-3 use the position data provided as part of the command as a relative position, adding the position given to the current graphical cursor position.  Codes 4-7 use the position data provided as part of the command as an absolute position, setting the current graphical cursor position to the position given.
+
+Codes 2 and 6 on Acorn systems plot using a logical inverse of the current pixel colour.  These operations cannot currently be supported by the graphics system the Agon VDP uses, so these codes are not supported.  Support for these codes may be added in a future version of the VDP firmware.
+
+
+## Compatibility
+
+If the VDP does not recognise a plot operation, it will be ignored.  This can allow you to write programs that "feature detect" whether the VDP supports a particular plot operation, and then use it if it does, or fall back to an alternative if it does not.

--- a/VDP---Screen-Modes.md
+++ b/VDP---Screen-Modes.md
@@ -1,0 +1,115 @@
+# Screen Modes
+
+The Agon VDP supports a number of different screen modes, which are listed below.
+
+Screen modes are selected using `VDU 22, mode`, or in BASIC using `MODE mode`.
+
+The list of screen modes available for use got revised and greatly expanded in VDP version 1.04.  The revision was mostly to make the screen modes more compatible with the VGA standards, and thus more compatible with modern monitors.  The original screen modes are still available, but are now considered legacy modes.
+
+It should be noted that whilst the Agon VDU command system is designed to be compatible with the BBC Micro, the screen modes are not.  The BBC Micro has a different set of screen modes, and the Agon VDP does not support them.
+
+By default, the Agon VDU system uses and adopts the BBC Micro's "logical" coordinate system for graphics, which means that each screen mode appears to be 1280x1024 to software with the graphics origin 0,0 point at the bottom left of the screen.  As a result programs written the BBC Micro can usually be fairly easily adapted.
+
+This logical coordinate system differs from the BBC Micro and later Acorn systems in that Acorn systems all used round numbers for the multiplier between the logical and physical coordinate systems.  (This meant that on later Acorn systems some screen modes used logical resolutions other than 1024x1280, depending on the physical resolution of the mode.)  On Agon systems, the multiplier for the vertical resolution is, essentially never a round number.
+
+To work around the limitations of the logical coordinate system, it is possible to change the graphics system to use physical coordinates instead of logical coordinates.
+
+There are two VDU commands that will affect the screen modes that are available, and how the drawing system works.
+
+## VDU Commands
+
+### `VDU 22, mode`
+
+This command selects a screen mode, where the screen mode is a single byte value qne muw5 be a mode from the list below.
+
+Screen modes numbered above 128 are double-buffered, meaning that the screen is drawn to an off-screen buffer, and then the buffer is copied to the screen.  This prevents flickering when drawing to the screen.
+
+As drawing operations, when in a double-buffered mode, are only performed in the off-screen buffer this means that the screen will not be updated until the active buffer is swapped.  This means, for instance, that if you enter a double-buffered screen mode in BASIC by using `MODE 129` then commands that you type will not be visible, as your input is being written to the off-screen buffer.  Commands will still be processed, but you will only see their effect when the buffer is swapped.  Buffers are swapped using `VDU 23, 0, &C3`
+
+It may sometimes not be possible to change into a screen mode, for instance because the VDP no longer has enough memory to support the mode.  In this case the system will fall back to the current mode, and if that fails to the default mode, which is mode 1.  All modes should always be available after a reset.
+
+### `VDU 23, 0, &C0, n`
+
+Turn logical screen scaling on and off, where 1=on and 0=off.
+
+When logical scaling is turned off, the graphics system will no longer use the 1280x1024 logical coordinate system and instead use pixel coordinates.  The screen origin point at 0,0 will change to be the top left of the screen, and the Y axis will go down the screen instead of up.  
+
+Support for this was added in VDP 1.03.
+
+
+### `VDU 23, 0, &C1, n`
+
+Switch legacy modes on or off.
+
+By default, the original screen modes 0-4 are not available and are instead replaced by new modes that are more compatible with modern monitors.  For compatibility with older software, written for Agon systems running earlier versions of the VDP firmware, this command can be used to switch back to those original, legacy, screen modes.
+
+Support for this was added in VDP 1.04
+
+
+### `VDU 23, 0, &C3`
+
+Swap the screen buffer (double-buffered modes only) or wait for VSYNC (all modes).
+
+This command will swap the screen buffer, if the current screen mode is double-buffered, doing so at the next VSYNC.  If the current screen mode is not double-buffered then this command will wait for the next VSYNC signal before returning.  This can be used to synchronise the screen with the vertical refresh rate of the monitor.
+
+Waiting for VSYNC can be useful for ensuring smooth graphical animation, as it will prevent tearing of the screen.
+
+(In BASIC performing a `*FX 19` command will also wait for VSYNC, but will not swap the screen buffer.)
+
+Support for this was added in VDP 1.04
+
+
+## Screen modes
+
+Modes over 128 are double-buffered
+
+### From Version 1.04 or greater
+
+| Mode | Horz | Vert | Cols | Refresh |
+|-----:|-----:|-----:|-----:|--------:|
+|    0 |  640 |  480 |   16 |    60hz |
+|  * 1 |  640 |  480 |    4 |    60hz |
+|    2 |  640 |  480 |    2 |    60hz |
+|    3 |  640 |  240 |   64 |    60hz |
+|    4 |  640 |  240 |   16 |    60hz |
+|    5 |  640 |  240 |    4 |    60hz |
+|    6 |  640 |  240 |    2 |    60hz |
+| ** 7 |  n/a |  n/a |   16 |    60hz |
+|    8 |  320 |  240 |   64 |    60hz |
+|    9 |  320 |  240 |   16 |    60hz |
+|   10 |  320 |  240 |    4 |    60hz |
+|   11 |  320 |  240 |    2 |    60hz |
+|   12 |  320 |  200 |   64 |    70hz |
+|   13 |  320 |  200 |   16 |    70hz |
+|   14 |  320 |  200 |    4 |    70hz |
+|   15 |  320 |  200 |    2 |    70hz |
+|   16 |  800 |  600 |    4 |    60hz |
+|   17 |  800 |  600 |    2 |    60hz |
+|   18 | 1024 |  768 |    2 |    60hz |
+|  129 |  640 |  480 |    4 |    60hz |
+|  130 |  640 |  480 |    2 |    60hz |
+|  132 |  640 |  240 |   16 |    60hz |
+|  133 |  640 |  240 |    4 |    60hz |
+|  134 |  640 |  240 |    2 |    60hz |
+|  136 |  320 |  240 |   64 |    60hz |
+|  137 |  320 |  240 |   16 |    60hz |
+|  138 |  320 |  240 |    4 |    60hz |
+|  139 |  320 |  240 |    2 |    60hz |
+|  140 |  320 |  200 |   64 |    70hz |
+|  141 |  320 |  200 |   16 |    70hz |
+|  142 |  320 |  200 |    4 |    70hz |
+|  143 |  320 |  200 |    2 |    70hz |
+
+\* Mode 1 is the "default" mode, and is the mode that the system will use on startup.  It is also the mode that the system will fall back to use if it was not possible to change to the requested mode.
+
+\** Mode 7 is the "Teletext" mode, and essentially works in a very similar manner to the BBC Micro's Teletext mode, which was also mode 7.
+
+
+### Legacy modes (prior to 1.04)
+
+| Mode | Horz | Vert | Cols | Refresh |
+|-----:|-----:|-----:|-----:|--------:|
+| 0    | 1024 |  768 |    2 | 60hz    |
+| 1    |  512 |  384 |   16 | 60hz    |
+| 2    |  320 |  200 |   64 | 75hz    |
+| 3    |  640 |  480 |   16 | 60hz    |

--- a/VDP---System-Commands.md
+++ b/VDP---System-Commands.md
@@ -1,0 +1,362 @@
+# VDP System Commands
+
+`VDU 23, 0` is reserved for commands sent to the VDP.  These are largely unique to the Agon, and are used to access some of the more sophisticated features of the VDP.
+
+Some of the commands are used for operating system functionality, and will not usually need to be used by user applications, whilst others allow access to features that applications will want to use.
+
+Please note that not all versions of the VDP support the complete command set.  The following list uses the following symbols to indicate which VDP versions support which commands:
+
+ \* Requires VDP 1.03 or above<br>
+ \** Requires VDP 1.04 or above<br>
+ § Requires Console8 VDP 2.3.0 or above<br>
+ §§ Requires Console8 VDP 2.4.0 or above
+
+Commands between &80 and &89 will return their data back to the eZ80 via the [serial protocol](#serial-protocol).
+
+NB:
+
+- Prior to MOS 1.03 the subset commands that it supported were indexed from &00, not &80. For example, `VDU 23, 0, &02` to request the cursor position.
+
+
+## `VDU 23, 0, &80, n`: General poll
+
+This command will echo back `n` to MOS (see [Serial Protocol](#serial-protocol))
+
+This command is used by MOS and the VDP to synchronise with each other during the system start-up process.  It is not intended to be used by applications.
+
+## `VDU 23, 0, &81, n`: Set the keyboard locale
+
+Sets the keyboard to a given locale/format.  The following locales are supported:
+
+| Locale | Description |
+| ------ | ----------- |
+| 0 | UK |
+| 1 | US |
+| 2 | German |
+| 3 | Italian |
+| 4 | Spanish |
+| 5 | French |
+| 6 | Belgian |
+| 7 | Norwegian |
+| 8 | Japanese ** |
+| 9 | US International ** |
+| 10 | US International Alternate ** |
+| 11 | Swiss German ** |
+| 12 | Swiss French ** |
+| 13 | Danish ** |
+| 14 | Swedish ** |
+| 15 | Portuguese ** |
+| 16 | Brazilian Portuguese § |
+| 17 | Dvorak § |
+
+Any other value will be interpreted as UK.
+
+## `VDU 23, 0, &82`: Request text cursor position
+
+This command will return the current text cursor position to MOS.  Once the cursor position has been returned the text cursor position data inside MOS's system variables will be updated to reflect the current cursor position.
+
+## `VDU 23, 0, &83, x; y;`: Get ASCII code of character at character position x, y
+
+This command will return the ASCII code of the character at the given character position to MOS.
+
+This command works by comparing pixels on the screen at the given position to the currently defined character set, using the currently selected text colour.  This means that it may not always be accurate, or able to succeed.  Redefining characters after they have been drawn, or changing the text colour, may cause this command to fail.
+
+This command will not recognise characters that have been mapped to bitmaps using `VDU 23, 0, &92, char, bitmapId;`.
+
+## `VDU 23, 0, &84, x; y;`: Get colour of pixel at pixel position x, y
+
+This command will return the colour of the pixel at the given pixel position to MOS.  The corresponding MOS system variables will be updated to reflect the read pixel colour.
+
+## `VDU 23, 0, &85, channel, command, <args>`: Audio commands
+
+Sends a command to the [VDP Enhanced Audio API](VDP---Enhanced-Audio-API.md) **
+
+Prior to VDP 1.04 this command could only perform what is now audio command zero, which plays a note on a channel.
+
+## `VDU 23, 0, &86`: Fetch the screen dimensions
+
+Returns the screen dimensions to MOS.  Generally applications should not need to call this, as this information will be automatically sent to MOS when the screen mode is changed.
+
+## `VDU 23, 0, &87`: RTC control *
+
+This command controls the Real Time Clock within the Agon VDP.
+
+- `VDU 23, 0, &87, 0`: Read the RTC
+  - a data packet will be sent to MOS with the current RTC data, and MOS system variables updated accordingly
+
+- `VDU 23, 0, &87, 1, y, m, d, h, m, s`: Set the RTC
+
+
+## `VDU 23, 0, &88, delay; rate; led`: Keyboard Control *
+
+This command controls the keyboard repeat delay, repeat rate, and LED status.
+
+Only delay values between 250 and 1000 are supported, and represents a time in milliseconds before the key will start repeating.
+
+The rate value represents the time between key repeats, and is given in milliseconds.  Values from 33-500 are supported.
+
+The LED value is a bit mask that controls the state of the keyboard LEDs.  The following bits are defined:
+
+| Bit | Name | Meaning |
+| --- | ---- | ------- |
+| 0 | Scroll Lock | If set then the Scroll Lock LED will be turned on.  If clear then it will be turned off. |
+| 1 | Caps Lock | If set then the Caps Lock LED will be turned on.  If clear then it will be turned off. |
+| 2 | Num Lock | If set then the Num Lock LED will be turned on.  If clear then it will be turned off. |
+
+## `VDU 23, 0, &89, command, [<args>]`: Mouse control **
+
+Commands beginning with `VDU 23, 0, &89` are reserved for mouse control, and are implemented from VDP 1.04 onwards.
+
+### `VDU 23, 0, &89, 0`: Enable the mouse
+
+Enables the mouse cursor, and will start sending mouse data packets to MOS.
+
+If there is no mouse connected then this command will have no effect.
+
+### `VDU 23, 0, &89, 1`: Disable the mouse
+
+Disables the mouse cursor, and will stop sending mouse data packets to MOS.
+
+### `VDU 23, 0, &89, 2`: Reset the mouse
+
+Resets the mouse system restoring default settings.
+
+### `VDU 23, 0, &89, 3, cursorId;`: Set mouse cursor
+
+Sets the mouse cursor to the given cursor ID.
+
+There are several built-in mouse cursors that are available for use.  These have been inherited from fab-gl and are numbered from 0-18.  The "Cursor" column in the table below shows the fab-gl name for the cursor.
+
+| ID | Cursor | Description |
+| -- | ------ | ----------- |
+| 0  | PointerAmigaLike | 11x11 Amiga like colored mouse pointer |
+| 1  | PointerSimpleReduced | 10x15 mouse pointer |
+| 2  | PointerSimple | 11x19 mouse pointer |
+| 3  | PointerShadowed | 11x19 shadowed mouse pointer |
+| 4  | Pointer | 12x17 mouse pointer |
+| 5  | Pen | 16x16 pen |
+| 6  | Cross1 | 9x9 cross |
+| 7  | Cross2 | 11x11 cross |
+| 8  | Point | 5x5 point |
+| 9  | LeftArrow | 11x11 left arrow |
+| 10 | RightArrow | 11x11 right arrow |
+| 11 | DownArrow | 11x11 down arrow |
+| 12 | UpArrow | 11x11 up arrow |
+| 13 | Move | 19x19 move |
+| 14 | Resize1 | 12x12 resize orientation 1 |
+| 15 | Resize2 | 12x12 resize orientation 2 |
+| 16 | Resize3 | 11x17 resize orientation 3 |
+| 17 | Resize4 | 17x11 resize orientation 4 |
+| 18 | TextInput | 7x15 text input |
+
+Additional cursors can be defined using the `VDU 23, 27, &40, hotX, hotY` command.  For details of that command see the [Bitmaps API](VDP---Bitmaps-API.md) documentation.  Using that API it is possible to define a custom mouse cursor using a bitmap, which can then be selected using this command passing in the 16-bit bitmapId in place of a cursorId.
+
+### `VDU 23, 0, &89, 4, x; y;`: Set mouse cursor position
+
+Explicitly moves the mouse cursor to a given position on the screen.
+
+### `VDU 23, 0, &89, 5, x1; y1; x2; y2;`: Reserved
+
+This command is reserved for future use.  It is not yet implemented.
+
+(When implemented it will set the mouse area, which will restrict the mouse cursor to a given area of the screen.  The mouse cursor will not be able to leave this area.)
+
+### `VDU 23, 0, &89, 6, sampleRate`: Set mouse sample rate
+
+Sets the rate at which mouse data will be sampled.  The rate given is a number of samples per second.  The default rate is 60.
+
+Valid sample rates are 10, 20, 40, 60, 80, 100, and 200 (samples/sec).  Any other values will be ignored.
+
+### `VDU 23, 0, &89, 7, resolution`: Set mouse resolution
+
+Sets the mouse resolution.  Values in the range 0-3 are supported, or 255 (-1) to pick the default resolution.  The default resolution is 2.
+
+The following resolutions are supported:
+
+| Value | Resolution |
+| ----- | ---------- |
+| 0 | 1 count per mm (25 dpi) |
+| 1 | 2 counts per mm (50 dpi) |
+| 2 | 4 counts per mm (100 dpi) (default) |
+| 3 | 8 counts per mm (200 dpi) |
+
+### `VDU 23, 0, &89, 8, scaling`: Set mouse scaling
+
+Sets the mouse scaling factor.  Only values `1` and `2` are supported to indicate 1:1 or 1:2 scaling.  Additionally a value of `0` can be sent to indicate "default" scaling, which is 1:1.
+
+### `VDU 23, 0, &89, 9, acceleration;`: Set mouse acceleration
+
+This sets the mouse acceleration factor to a 16-bit value.  Setting the value to `0` will result in the default acceleration being used, which is 180.  The suggested range for this is 0-2000.
+
+### `VDU 23, 0, &89, 10, wheelAcceleration; wheelAccHighByte`: Set mouse wheel acceleration (accepts a 24-bit value)
+
+Sets the wheel acceleration factor to a 24-bit value.  Setting the value to `0` will result in the default acceleration being used, which is 60000.  The suggested range for this is 0-100000.
+
+### Mouse data packets
+
+Mouse data packets are sent in response to all of the above commands, and if the mouse has been enabled whenever the mouse is moved.  This ensures that mouse data is constantly updated in MOS system variables.
+
+
+## `VDU 23, 0, &90, n, b1, b2, b3, b4, b5, b6, b7, b8`: Redefine character n (0-255) with 8 bytes of data §
+
+This command works identically to `VDU 23, n, b1, b2, b3, b4, b5, b6, b7, b8`, but allows characters 0-31 to also be redefined.
+
+## `VDU 23, 0, &91`: Reset all characters to original definition §
+
+This command will reset all characters to their original definitions.
+
+## `VDU 23, 0, &92, char, bitmapId;`: Map character char to display bitmapId §§
+
+This command will map a character to a bitmap.  The bitmap ID given must be a valid bitmap ID.  The purpose of this command is to allow for fast and efficient drawing of bitmaps to the screen, by allowing them to be drawn as characters.
+
+Any character number can be used, including those in the range of 0-31, or the usual/normal alphabetic range.  This could be used, for instance, to create a custom colour font.  It could alternatively be used with characters in the range of 128-255 to define a custom graphical tile-set, like PETSCII but in colour.
+
+When a character has been mapped to use a bitmap the bitmap will be used in place of that character, and will be drawn at the current text cursor position, placing the bottom left of the bitmap at the cursor position.  The cursor position will then be moved to the right by the width of a character, and _not_ by the width of the bitmap.
+
+That last point is important.  It means that if you use a bitmap that is larger than a character, then the next character will overlap the bitmap.  Similarly bitmaps that are taller than a character will overwrite the line of text above the current cursor.  This can be used to create some interesting effects, but can also be a source of visual bugs if you are not careful.  If you are using oversized bitmaps, then using the `VDU 9` to move forward an additional character may be useful.
+
+
+## `VDU 23, 0, &94, n`: Read colour palette entry n (returns a pixel colour data packet) §§
+
+This command will return the colour of the given palette entry to MOS.  This data is sent using a "screen pixel" data packet.  The corresponding MOS system variables related to screen pixel colour will be updated to reflect the read palette entry.
+
+The Agon VDP system supports a 64 colour palette, so values in the range of 0-63 will return data on that palette entry.  The following special values are also supported:
+
+| Value | Description |
+| ----- | ----------- |
+| 128 | The current text foreground colour |
+| 129 | The current text background colour |
+| 130 | The current graphics foreground colour |
+| 131 | The current graphics background colour |
+
+Any other colour value will not be recognise, and no response sent.
+
+## `VDU 23, 0, &A0, bufferId, command, <args>`: Buffered command API **
+
+Send a command to the [VDP Buffered Commands API](VDP---Buffered-Commands-API.md)
+
+## `VDU 23, 0, &A1`: Update VDP (for exclusive use of the agon-flash tool) **
+
+This command is used by the agon-flash tool to update the VDP firmware.  It should not be used by any other software.
+
+## `VDU 23, 0, &C0, n`: Turn logical screen scaling on and off *
+
+Turns logical screen scaling on and off, where 1=on and 0=off.
+
+When logical scaling is turned off, the graphics system will no longer use the 1280x1024 logical coordinate system and instead use pixel coordinates.  The screen origin point at 0,0 will change to be the top left of the screen, and the Y axis will go down the screen instead of up.  
+
+For more information, see the [Screen modes documentation](VDP---Screen-Modes.md).
+
+## `VDU 23, 0, &C1, n`: Switch legacy modes on or off **
+
+Turns legacy screen modes on and off, where 1=on and 0=off.
+
+By default, the original screen modes 0-4 are not available and are instead replaced by new modes that are more compatible with modern monitors.  For compatibility with older software, written for Agon systems running earlier versions of the VDP firmware, this command can be used to switch back to those original, legacy, screen modes.
+
+For more information, see the [Screen modes documentation](VDP---Screen-Modes.md).
+
+
+## `VDU 23, 0, &C3`: Swap the screen buffer and/or wait for VSYNC **
+
+Swap the screen buffer (double-buffered modes only) or wait for VSYNC (all modes).
+
+This command will swap the screen buffer, if the current screen mode is double-buffered, doing so at the next VSYNC.  If the current screen mode is not double-buffered then this command will wait for the next VSYNC signal before returning.  This can be used to synchronise the screen with the vertical refresh rate of the monitor.
+
+Waiting for VSYNC can be useful for ensuring smooth graphical animation, as it will prevent tearing of the screen.
+
+(In BASIC performing a `*FX 19` command will perform a similar wait for VSYNC, but on the eZ80 side of the system, but will not swap the screen buffer.)
+
+
+## `VDU 23, 0, &FE, n`: Console mode **
+
+Turns "console mode" on and off, where 1=on and 0=off (the default).
+
+This mode is primarily intended for use with debugging tooling.  It will reflect VDU command bytes through to a serial terminal attached to the VDPs USB port, and will attempt to pass keyboard input from the serial terminal back through the VDP to MOS.
+
+This mode is not intended for general use.  If you are looking for a way to output data to the attached serial terminal then `VDU 2` is a better option.
+
+
+## `VDU 23, 0, &FF`: Switch to or resume "terminal mode"
+
+This command enables "terminal mode", which changges the behaviour of the VDP to be more like a traditional terminal.  This is useful for running CP/M in place of MOS on the eZ80, or other software that expects to be running on a terminal.
+
+When terminal mode is enabled, VDU commands will no longer be recognised and processed, keyboard entry in BBC BASIC/MOS is no longer supported, and the VDP protocol is essentially suspended.  Instead the VDP acts as a dumb terminal, and will send all keyboard input to the eZ80's UART0.  The eZ80 can then process this input as it sees fit.
+
+By default a VT100 terminal is emulated, but this can be changed by sending the appropriate escape sequences to the VDP.  Terminal support is inherited from FabGL, and so its [custom escape sequences](http://www.fabglib.org/special_term_escapes.html) can be used to change the terminal behaviour.
+
+From Console8 VDP version 2.2.0, the following additional escape sequences are supported:
+
+| Sequence | Description |
+| -------- | ----------- |
+| `ESC + "_#Q!"` | Quit/end terminal mode |
+| `ESC + "_#S!"` | Suspend terminal mode |
+
+Quitting terminal mode returns the VDP back to normal operation, and will resume the VDP protocol.  The screen mode will be reset to the mode that was active before terminal mode was enabled.
+
+Suspending terminal mode temporarily restores VDU command processing.  (Keyboard handling is unchanged.)  This could be useful to use VDU commands to perform drawing operations.  To resume terminal mode, `VDU 23, 0, &FF` must be sent again.
+
+
+
+## Serial Protocol
+
+Data sent from the VDP to the eZ80's UART0 is sent as a packet in the following format:
+
+- cmd: The packet command, with bit 7 set
+- len: Number of data bytes
+- data: The data byte(s)
+
+Words are 16 bit, and sent in little-endian format
+
+In general, as a programmer using an Agon you should not need to worry about the format and contents of any of these packets, as they are handled by MOS.  On receipt of one of these packets, MOS will set system variables accordingly.  It also sets a bit in the VDPProtocol status byte corresponding to the type of data packet received.
+
+If you are performing a command where you need to wait for a response from the VDP, then you will need to wait for the appropriate bit to be set in the VDP protocol byte.  Before you send a command to the VDP you should clear the bit that relates to the command you are about to send.  Once the command has been processed the VDP will set the bit again.  If the bit is not set then there may have been an error processing the command.
+
+Packets:
+
+- `0x00, value`: General Poll
+- `0x01, keycode, modifiers, vkey, keydown`: Keyboard state
+- `0x02, x, y`: Cursor position
+- `0x03, char`: Character read from screen
+- `0x04, r, g, b, index`: Pixel colour read from screen
+- `0x05, channel, status`: Audio command status (see [VDP Enhanced Audio API](VDP---Enhanced-Audio-API.md))
+- `0x06, width; height; cols, rows, colours`: Screen dimensions - width and height are words
+- `0x07, year, month, day, dayOfYear, dayOfWeek, hour, minute, second`: RTC data *
+- `0x08, delay, rate, led`: Keyboard status - delay and rate are words
+- `0x09, x; y; buttons, wheelDelta, deltaX; deltaY;`: Mouse status - x, y, deltaX and deltaY are words
+
+\* as of VDP 1.04 the RTC data is sent in a packed format.  This is interpreted by MOS and expanded into the appropriate system variables.  Prior to VDP 1.04 the `dayOfYear` value could be incorrect, as it cannot be guaranteed to fit into a byte.
+
+MOS VDP Protocol flag bits:
+
+| Bit | Description |
+| --- | ----------- |
+| 0 | Cursor position |
+| 1 | Character read from screen |
+| 2 | Point data (pixel colour) read from screen |
+| 3 | Audio status |
+| 4 | Mode info / Screen dimensions |
+| 5 | RTC data |
+| 6 | Mouse status |
+
+
+### Keyboard
+
+When a key is pressed, a packet is sent with the following data:
+- cmd: 0x01
+- keycode: The ASCII value of the key pressed
+- modifiers: A byte with the following bits set (1 = pressed):
+```
+0. CTRL
+1. SHIFT
+2. ALT LEFT
+3. ALT RIGHT
+4. CAPS LOCK
+5. NUM LOCK
+6. SCROLL LOCK
+7. GUI
+```
+From VDP 1.03, the following key data is also returned
+- vkey: The FabGL virtual keycode
+- keydown: 1 if the key is down, 0 if the key is up
+
+

--- a/VDP---VDU-Commands.md
+++ b/VDP---VDU-Commands.md
@@ -1,0 +1,319 @@
+# An Overview of VDU Commands
+
+The Agon VDP system aims to be as compatible as practical with the Acorn BBC Micro's VDU command system.  It also supports some extensions as added by later Acorn computer systems, and the various versions of BBC BASIC by R.T.Russell.  Where necessary, some extensions have been added to help facilitate the Agon's unique features and architecture.
+
+This documentation provides a more in-depth explanation to each top-level VDU control code, and provides links to further documentation for more detailed individual commands.
+
+Please note that not all versions of the VDP support the complete command set.  The first version of the VDP to support the complete top-level list of VDU commands is the Agon Console8 VDP 2.5.0.  The following list uses the following symbols to indicate which VDP versions support which commands:
+
+ \* Requires VDP 1.03 or above<br>
+ \** Requires VDP 1.04 or above<br>
+ § Requires Console8 VDP 2.3.0 or above<br>
+ §§ Requires Console8 VDP 2.5.0 or above<br>
+
+In general, bytes/characters in the range of 0-31 are treated as control or command codes by the VDP.  Depending on the command, the VDP will then interpret bytes that follow as parameters to the command, continuing until sufficient bytes have been read to satisfy the command.  If there are insufficient bytes to satisfy the command, then the VDP will wait until more bytes are available, and timeout after 200ms.  If too many bytes are sent for a command, then the VDP will interpret those new bytes as another command.
+
+Any VDU command that is the VDP does not recognise (such as `VDU 2` when running on Quark 1.04) will be ignored.  Please note that when VDP comes across a command it does not understand it will proceed to interpret the next byte it receives as the next command.  This means that code written for a later version of the VDP may not work correctly on earlier versions and produce unexpected results.  Care should be taken to ensure that code is compatible with the VDP version it is running on, and it is generally advised to try to detect features before using them.
+
+All other characters, i.e. those in the range of 32 to 126 and 128 to 255, are sent to the screen as ASCII, unaltered.
+
+## `VDU 0`: Null (no operation)
+
+On encountering a `VDU 0` command, the VDP will do nothing.  This may be useful for padding out a VDU command sequence, or for inserting a placeholder for a command that will be added later.
+
+## `VDU 1`: Send next character to "printer" (if "printer" is enabled) §§
+
+Ensures that the next character received by the VDP is sent through to the "printer", and not to the screen.  This is useful for sending control codes to the "printer", or for sending data to the "printer" that is not intended to be displayed on the screen.  It allows characters that would not otherwise normally be sent through to the "printer" to be sent.
+
+If the "printer" has not been enabled then this command will just discard the next byte sent to the VDP.
+
+## `VDU 2`: Enable "printer" §§
+
+Enables the "printer".
+
+In the context of the Agon platform, the "printer" is a serial terminal that is connected to the VDP's USB port.  Typically this port is used for power, but it can also be used to send and receive data to and from the VDP.
+
+When the "printer" is enabled, the VDP will send characters it receives to the "printer" as well as to the screen.  It will additionally send through control codes 8-13.  To send other control codes to the "printer", use the `VDU 1` command.
+
+The VDP will not send through other control codes to the printer, and will will not send through data it receives as part of other commands.
+
+## `VDU 3`: Disable "printer" §§
+
+Disables the "printer".
+
+## `VDU 4`: Write text at text cursor
+
+This causes text to be written at th current text cursor position.  This is the default mode for text display.
+
+Text is written using the current text foreground and background colours.
+
+## `VDU 5`: Write text at graphics cursor
+
+This causes text to be written at the current graphics cursor position.
+
+Using this, characters may be positioned at any graphics coordinate within the graphics viewport.  This is useful for positioning text over graphics, or for positioning text at a specific location on the screen.
+
+Characters are plotted using the current graphics foreground colour, using the current graphics foreground plotting mode (see `VDU 18`).
+
+The character background is transparent, and will not overwrite any graphics that are already present at the character's location.  The exception to this is `VDU 27`, the "delete" character, which backspaces and deletes as per its usual behaviour, but will erase using the current graphics background colour.
+
+## `VDU 6`: Enable screen (opposite of `VDU 21`) §§
+
+This enables the screen, and re-enables VDU command processing, reversing the effect of `VDU 21`.
+
+## `VDU 7`: Make a short beep (BEL)
+
+Plays a short beep sound on audio channel 0.  If the audio channel is already in use, or has been disabled, then this command will have no effect.
+
+## `VDU 8`: Move cursor back one character
+
+Moves the text cursor one character in the negative "X" direction.  By default, when at the start of a line it will move to the end of the previous line (as defined by the current text viewport).  If the cursor is also at the top of the screen then the viewport will scroll down.  The cursor remains constrained to the current text viewport.
+
+When in `VDU 5` mode and the graphics cursor is active, the viewport will not scroll.  The cursor is just moved left by one character width.
+
+Further behaviour of the cursor can be controlled using the `VDU 23,16` command.
+
+It should be noted that as of Console8 VDP 2.5.0, the cursor system does not support adjusting the direction of the cursor's X axis, so this command will move the cursor to the left.  This is likely to change in the future.
+
+## `VDU 9`: Move cursor forward one character
+
+Moves the text cursor one character in the positive "X" direction.  By default, when at the end of a line it will move to the start of the next line (as defined by the current text viewport).  If the cursor is also at the bottom of the screen then the viewport will scroll up.
+
+Essentially this is the opposite of `VDU 8`.
+
+When in `VDU 5` mode and the graphics cursor is active, the viewport will not scroll.
+
+## `VDU 10`: Move cursor down one line
+
+Moves the text cursor one line in the positive "Y" direction.  By default, when at the bottom of the screen the viewport will scroll upwards.
+
+When in `VDU 5` mode and the graphics cursor is active, the viewport will not scroll, and the cursor is just moved down by one character height.
+
+## `VDU 11`: Move cursor up one line
+
+Moves the text cursor one line in the negative "Y" direction.  By default, when at the top of the screen the viewport will scroll downwards.
+
+Essentially this is the opposite of `VDU 10`.
+
+When in `VDU 5` mode and the graphics cursor is active, the viewport will not scroll.
+
+## `VDU 12`: Clear text area (`CLS`)
+
+Clears the current text viewport to the current text background colour, and moves the text cursor to the "home" position of the viewport (usually the top left).
+
+This is identical to the BASIC `CLS` keyword.
+
+## `VDU 13`: Carriage return
+
+Moves the text cursor to the start (or column 0) of the current line.
+
+## `VDU 14`: Page mode On *
+
+When page mode is on, scrolling will stop after each page.  Output will be paused until "Shift" has been pressed on the keyboard.
+
+## `VDU 15`: Page mode Off *
+
+Disables page mode.  This is the default mode.
+
+## `VDU 16`: Clear graphics area (`CLG`)
+
+Clears the current graphics viewport to the current graphics background colour.
+
+The current graphics cursor is unaffected.
+
+This is identical to the BASIC `CLG` keyword.
+
+## `VDU 17, colour`: Set text colour (`COLOUR`)
+
+This will set the current text colour to the given colour, as defined by the colour palette.
+
+Colour numbers in the range 0-127 are interpreted as foreground colours, and numbers in the range 128-255 are interpreted as background colours.
+
+The actual range of colours supported will depend on the screen mode you are using.  Agon systems can only actually display a maximum of 64 colours (numbered 0 to 63).  The VDP will loop around the colour palette if a colour number is given that is outside the range of colours supported by the screen mode.  This means that for instance colour 65 is always equivalent to colour 1, or when in a 16 colour screen mode selecting colour 32 would be equivalent to choosing colour 0.
+
+This command is identical to the BASIC `COLOUR` keyword.
+
+## `VDU 18, mode, colour`: Set graphics colour (`GCOL mode, colour`)
+
+This command will set both the current graphics colour, and the current graphics plotting mode.
+
+As with `VDU 17` the colour number will set the foreground colour if it is in the range 0-127, or the background colour if it is in the range 128-255, and will be interpreted in the same manner.
+
+Support for different plotting modes on Agon is currently very limited.  The only fully supported mode is mode 0, which is the default mode.  This mode will plot the given colour at the given graphics coordinate, and will overwrite any existing graphics at that coordinate.  There is very limited support for mode 4, which will invert the colour of any existing graphics at the given coordinate, but this is not fully supported and may not work as expected.
+
+Support for other plotting modes, matching those provided by Acorn's original VDU system, may be added in the future.
+
+This command is identical to the BASIC `GCOL` keyword.
+
+## `VDU 19, l, p, r, g, b`: Define logical colour (`COLOUR l, p` / `COLOUR l, r, g, b`)
+
+This command sets the colour palette, by mapping a logical colour to a physical colour.  This is useful for defining custom colours, or for redefining the default colours.
+
+If the physical colour number is given as 255 then the colour will be defined using the red, green, and blue values given.  If the physical colour number is given as any other value then the colour will be defined using the colour palette entry given by that number, up to colour number 63.
+
+If the physical colour is not 255 then the red, green, and blue values must still be provided, but will be ignored.
+
+The values for red, green and blue must be given in the range 0-255.  You should note that the physical Agon hardware only supports 64 colours, so the actual colour displayed may not be exactly the same as the colour requested.  The nearest colour will be chosen.
+
+This command is equivalent to the BASIC `COLOUR` keyword.
+
+## `VDU 20`: Reset palette and text/graphics colours and drawing modes §§
+
+This command will reset the colour palette to the default palette, and will reset the text and graphics colours and drawing modes to their default values.
+
+## `VDU 21`: Disable screen §§
+
+This command will "disable the screen", stopping any further VDU commands from being processed.  This is useful for temporarily disabling the screen, for instance when using the "printer" to send data to a serial terminal.  The actual screen display will not be turned off, but the VDP will stop processing VDU commands so changes to the display will not be made until the screen is re-enabled.
+
+The exception to this is commands `VDU 1` and `VDU 6`, which will still be processed.  If the "printer" has been enabled, bytes sent to the VDP still be sent through to the "printer", with the restrictions as described against `VDU 2`.
+
+Please note that the behaviour of the Agon system differs from Acorn systems when `VDU 21` has been called.  On an Agon system, when the screen has been disabled the VDP will consider each and every byte received as a new command, looking out specifically for a `VDU 6` command byte to re-enable the command interpreter.  It will not attempt to interpret any bytes received as a parameter to the previous command.  An Acorn system, on the other hand, would accept parameters for VDU commands, and just not process the command.  This means that code written for an Acorn system may not work correctly on an Agon system if it uses `VDU 21`.
+
+## `VDU 22, n`: Select screen mode (`MODE n`)
+
+Changes the screen mode to the given mode number.
+
+Please see the [Screen Modes](VDP---Screen-Modes.md) documentation for more information on the screen modes supported by the Agon VDP.
+
+This command is identical to the BASIC `MODE` keyword.
+
+## `VDU 23, n`: Re-program display character / System Commands
+
+This command serves two purposes.
+
+Firstly when `n` is in the range of 32-255 it will re-program the character in the character set at the given character code.  This is useful for redefining the character set, or for adding custom characters to the character set.  The format of the command in this mode is:
+```
+VDU 23, char_no, r1, r2, r3, r4, r5, r6, r7, r8
+```
+Where `char_no` is the character number to re-program, and `r1` to `r8` are the 8 bytes of data that define the character in rows from top to bottom.  Each byte defines one row of the character, with the least significant bit of each byte defining the left-most pixel of the row, and the most significant bit defining the right-most pixel of the row.
+
+The second purpose of this command is to send system commands to the VDP.
+
+The following commands are supported:
+
+### `VDU 23, 0, <command>, [<arguments>]`: System commands
+
+Commands starting with `VDU 23, 0` are system commands.  These commands are used to configure the VDP and to control its behaviour.  This includes functionality such as the [audio system](VDP---Enhanced-Audio-API.md) and the [buffered commands API](VDP---Buffered-Commands-API.md).  For more information see the [System Commands](VDP---System-Commands.md) documentation.
+
+### `VDU 23, 1, n`: Cursor control 
+
+This command will enable or disable the text cursor.  Setting a vbalue of 0 disables the cursor, and setting a value of 1 enables the cursor.
+
+### `VDU 23, 7, extent, direction, movement`: Scroll
+
+This command scrolls in a given direction.
+
+The `extent` parameter controls what part of the screen will be scrolled.  A value of `0` means the current text viewport, a `1` means the whole screen, a `2` means the current graphics viewport, and `3` is interpreted as the current "active" viewport (as per VDU 4 or VDU 5).
+
+The `direction`` parameter can be one of the following values:
+
+| Value | Meaning |
+| ----- | ------- |
+| 0 | Scroll right |
+| 1 | Scroll left |
+| 2 | Scroll down |
+| 3 | Scroll up |
+| 4 | Scroll in positive X direction * |
+| 5 | Scroll in negative X direction * |
+| 6 | Scroll in positive Y direction * |
+| 7 | Scroll in negative Y direction * |
+
+\* Support for these values was added in Agon Console8 VDP 2.5.0.
+
+The positive/negative X/Y direction is defined via `VDU 23, 16`.
+
+The `movement` parameter controls the movement amount.  A value of `0` means that the screen will be scrolled by one character width/height in the given direction.  Any other value is interpreted as the number of pixels to scroll in the given direction.
+
+Support for a `movement` value of zero was added in Agon Console8 VDP 2.5.0.  Before this version a `movement` value of zero would be interpreted as no movement.
+
+The Agon implementation of this command differs from Acorn systems in the interpretation of the `movement` and `extent` parameter.  On Acorn systems, the only valid `extent` values are 0 or 1.  Acorn's `movement` parameter can only be 0 or 1 too, but vertical movement would always be one character height, and horizontal movement one character width for a movement value of 0, and one byte for a movement value of 1, which made the results of this command vary depending on the current screen mode.  The Agon implementation of this command allows for more flexibility, and allows for scrolling by a given number of pixels in any direction, at the cost of some compatibility.
+
+
+### `VDU 23, 16, setting, mask`: Define cursor movement behaviour
+
+This command controls the behaviour of the text cursor.  It is used to adjust the cursor behaviour via a bitmask.  The new setting is calculated as:
+```
+new_setting = (current_setting AND mask) EOR setting
+```
+
+The following bits are implemented in VDU 23, 16
+
+| Bit | Value | Meaning |
+| --- | ----- | ------- |
+| 7 | 0 | Normal value |
+| 7 | 1 | Undefined |
+| 6 | 0 | Graphics cursor does an implicit cr/lf when it moves off right of graphics viewport (default) |
+| 6 | 1 | Graphics cursor (VDU 5 mode) carries on off edge of graphics viewport |
+| 5 | 0 | Cursor moves right after a character is printed (default) |
+| 5 | 1 | Cursor does not move right after a character is printed |
+| 4 | 0 | Text cursor will scroll when it moves off the bottom of the screen (default) |
+| 4 | 1 | Text cursor will wrap to top of screen when it moves off the bottom of the screen |
+| 3, 2, 1 |  | Defines the cursor direction, as follows * |
+| 3, 2, 1 | 0 0 0 | X direction is right, Y direction is down (default) * |
+| 3, 2, 1 | 0 0 1 | X direction is left, Y direction is down * |
+| 3, 2, 1 | 0 1 0 | X direction is right, Y direction is up * |
+| 3, 2, 1 | 0 1 1 | X direction is left, Y direction is up * |
+| 3, 2, 1 | 1 0 0 | X direction is down, Y direction is right * |
+| 3, 2, 1 | 1 0 1 | X direction is down, Y direction is left * |
+| 3, 2, 1 | 1 1 0 | X direction is up, Y direction is right * |
+| 3, 2, 1 | 1 1 1 | X direction is up, Y direction is left * |
+| 0 | 0 | Disable scroll protection (default) |
+| 0 | 1 | Enable scroll protection - text cursor will not scroll when it moves off the bottom/right of the viewport |
+
+\* As of Console8 VDP 2.5.0 and Quark VDP 1.04 cursor direction is not currently supported for cursor movement.
+
+Console8 VDP 2.5.0 adds support for cursor direction for scrolling only via the `VDU 23, 7` command, and only for values where bit 3 is zero.  They are included here for completeness, and will be supported in the future.
+
+### `VDU 23, 27, <command>, [<arguments>]`: Bitmap and sprite commands
+
+See the [Bitmap and Sprite Commands](VDP---Bitmap-and-Sprite-Commands.md) documentation for more information.
+
+### `VDU 23, 28`: Hexload
+
+This command is used by the hexload utility, and should not be used by user applications.
+
+## `VDU 24, left; bottom; right; top;`: Set graphics viewport **
+
+This command sets the graphics viewport.  The graphics viewport defines the area of the screen that graphics will be drawn to.  It is also the area that will be cleared by the `VDU 16` command.
+
+## `VDU 25, mode, x; y;`: PLOT command
+
+This command is used for graphics plotting, and is equivalent to the BASIC `PLOT` command.
+
+The aim for this command is to support all of Acorn's original `PLOT` modes, however currently only a limited number of plotting modes are supported.  Support for plot modes has expanded over time, and will continue to expand in the future.
+
+For more information see the [Graphics Plotting](VDP---Graphics-Plotting.md) documentation.
+
+## `VDU 26`: Reset graphics and text viewports **
+
+This command resets the graphics and text viewports to their default values, homes the text cursor, and resets the graphics origin.  The default graphics viewport is the whole screen, and the default text viewport is the whole screen.
+
+## `VDU 27, char`: Output character to screen §
+
+Sends the next character to the screen.  This allows for characters outside of the normal ASCII range of 32-126 and 128-255 to be drawn on the screen.
+
+## `VDU 28, left, bottom, right, top`: Set text viewport **
+
+This defines a text viewport.  The text viewport defines the area of the screen that text will be drawn to.  It is also the area that will be cleared by the `VDU 12` command.
+
+The coordinates given are character positions, not pixel positions.
+
+## `VDU 29, x; y;`: Set graphics origin
+
+This command sets the graphics origin.  This sets where on the screen graphics coordinates are relative to for drawing commands.
+
+## `VDU 30`: Home cursor
+
+When in `VDU 4`` mode, this moves the text cursor to the home (top left) position of the current text viewport.  When in `VDU 5`` mode, this moves the graphics cursor to the home position of the current graphics viewport.
+
+## `VDU 31, x, y`: Move text cursor to x, y text position
+
+Moves the text cursor to the given text position.  The coordinates given are character positions, not pixel positions.
+
+This is equivalent to the BASIC `TAB(x, y)` statement.
+
+## `VDU 127`: Backspace
+
+Moves the text cursor back one character, and deletes the character at that position.
+
+

--- a/VDP.md
+++ b/VDP.md
@@ -9,7 +9,7 @@ The VDP is the Agon's Visual Display Processor. It is responsible for:
 
 It runs on the ESP32-Pico-D4 co-processor and uses a fork of the FabGL library (known as vdp-gl) to support those functions.
 
-At a higher level, its input is a byte stream from the eZ80F92 main CPU over an internal high-speed UART connection @ 1,152,000 baud (384,000 baud for versions of MOS/VDP prior to 1.03). This stream contains a mixture of text and control characters. These control characters are mapped to the BBC BASIC VDU control characters, a choice made as BBC BASIC for Agon is the pre-installed programming language of Agon.
+At a higher level, its input is a byte stream from the eZ80F92 main CPU over an internal high-speed UART connection @ 1,152,000 baud (384,000 baud for versions of MOS/VDP prior to 1.03). This stream contains a mixture of text and control characters. These control characters are mapped to the BBC BASIC VDU control characters, a choice made as BBC BASIC for Agon is the pre-installed programming language of Agon.  As a result, we refer to the commands that the VDP understands as VDU commands.
 
 The ESP32 also outputs data back to the eZ80F92, for example keyboard data and screen information via a custom serial protocol.
 
@@ -17,25 +17,57 @@ The ESP32 also outputs data back to the eZ80F92, for example keyboard data and s
 
 ### From BBC BASIC
 
-The VDU command interprets each of the integer values following the keyword as an ASCII value. Values between 0 and 255 are accepted, and are separated by commas. If the value is immediately followed by a semicolon `;` then the value is a little-endian word from 0 to 65535.
+The `VDU` statement in BBC BASIC essentially just means "send this data to the VDP".  It will accept any number of integer arguments between 0 and 255, separated by commas.  If a value is immediately followed by a semicolon `;` instead of a comma then the value is a little-endian word from 0 to 65535.
 
 Example:
 
 `VDU 25, 69, 640; 512;`: Plot a dot in the center of the screen
 
+`VDU 65`: Print the letter "A", without a newline
+
+A single `VDU` statement in BASIC can potentially contain multiple commands for the VDP to interpret, or a VDU command could instead be split across multiple `VDU` statements.  Other BASIC keywords that generate screen output are effectively just wrappers for VDU command sequences.
+
+For example, the following code snippets are all directly equivalent, and result in an identical command stream being sent to the VDP:
+
+```
+PLOT 69, 640, 512
+PRINT "A";
+```
+```
+VDU 25, 69, 640; 512; 65
+```
+```
+VDU 25
+VDU 69
+VDU 640; 512;
+VDU ASC("A")
+```
+```
+VDU 25, 69, 128, 2, 0, 2, 65
+```
+
 ### From MOS command line (Version 1.03 or greater)
 
-The VDU command accepts values between 0 and 255 and are separated by spaces.
+MOS also supports a VDU command which can be used to send VDU commands to the VDP.  This is useful for testing the VDP without having to write a BASIC program.  Its command is simpler than the BASIC equivalent, accepting only 8-bit integer values between 0 and 255, separated by spaces.
 
 Example:
 
 `VDU 17 15`: Set the text foreground colour to 15
 
+### From Assembly code on MOS
+
+MOS offers two ways to send VDU commands from assembly code.  The first is to use the `RST 10h` call, which will send the byte in the A register to the VDP.  The second is to use a `RST 18h` call which is used to send multiple bytes to the VDP at once.  (Neither of these calls require the string `VDU` to be included in the data sent to the VDP, and both require raw binary values to be sent, rather than an ASCII string.)
+
+More information about these can be found in the [MOS API documentation](MOS-API.md).
+
+
 ## VDU Character Sequences
 
 The aim is that the Agon's VDP should be as compatible as practical with the BBC Micro's VDU command, as well as the VDU commands supported by later versions of Acorn and R.T.Russell's BBC BASICs.  Where necessary, some extensions have been added to help facilitate the Agon's unique features and architecture.
 
-The following VDU sequences are supported:
+For a more detailed description of VDU commands supported by the Agon's VDP, see [VDU Commands](VDP---VDU-Commands.md).
+
+The following is a high-level list of the VDU sequences that are supported:
 
 - `VDU 0`: Null (no operation)
 - `VDU 1`: Send next character to "printer" (if "printer" is enabled) §§
@@ -59,7 +91,7 @@ The following VDU sequences are supported:
 - `VDU 19, l, p, r, g, b`: Define logical colour (`COLOUR l, p` / `COLOUR l, r, g, b`)
 - `VDU 20`: Reset palette and text/graphics colours and drawing modes §§
 - `VDU 21`: Disable screen (turns of VDU command processing, except for `VDU 1` and `VDU 6`) §§
-- `VDU 22, n`: Select screen mode (`MODE n`)
+- `VDU 22, n`: [Select screen mode](VDP---Screen-Modes.md) (`MODE n`)
 - `VDU 23, n`: Re-program display character / System Commands
 - `VDU 24, left; bottom; right; top;`: Set graphics viewport **
 - `VDU 25, mode, x; y;`: PLOT mode, x, y
@@ -81,217 +113,18 @@ Any VDU command that is the VDP does not recognise (such as `VDU 2` when running
  §§ Requires Console8 VDP 2.5.0 or above<br>
 
 
-## VDU 23, 0: VDP commands
+## VDU 23 commands
 
-VDU 23, 0 is reserved for commands sent to the VDP
+`VDU 23` essentially has a split purpose.  The first is to redefine the display characters, and the second is to send commands to the VDP to access some more sophisticated behaviour.
 
-- `VDU 23, 0, &80, n`: General poll, which echoes back `n` to MOS (see [Serial Protocol](#serial-protocol))
-- `VDU 23, 0, &81, n`: Set the keyboard locale (0=UK, 1=US, etc) 
-- `VDU 23, 0, &82`: Request text cursor position
-- `VDU 23, 0, &83, x; y;`: Get ASCII code of character at character position x, y
-- `VDU 23, 0, &84, x; y;`: Get colour of pixel at pixel position x, y
-- `VDU 23, 0, &85, channel, command, <args>`: Send a command to the [VDP Enhanced Audio API](VDP---Enhanced-Audio-API.md) **
-- `VDU 23, 0, &86`: Fetch the screen dimensions
-- `VDU 23, 0, &87`: RTC control *
-- `VDU 23, 0, &88, delay; rate; led`: Keyboard Control *
-- `VDU 23, 0, &89, command, [<args>]`: Mouse control **
-- `VDU 23, 0, &90, n, b1, b2, b3, b4, b5, b6, b7, b8`: Redefine character n (0-255) with 8 bytes of data §
-- `VDU 23, 0, &91`: Reset all characters to original definition §
-- `VDU 23, 0, &92, char, bitmapId;`: Map character char to display bitmapId §§
-- `VDU 23, 0, &94, n`: Read colour palette entry n (returns a pixel colour data packet) §§
-- `VDU 23, 0, &A0, bufferId, command, <args>`: Send a command to the [VDP Buffered Commands API](VDP---Buffered-Commands-API.md) **
-- `VDU 23, 0, &A1`: Update VDP (for exclusive use of the agon-flash tool) **
-- `VDU 23, 0, &C0, n`: Turn logical screen scaling on and off, where 1=on and 0=off *
-- `VDU 23, 0, &C1, n`: Switch legacy modes on or off **
-- `VDU 23, 0, &C3`: Flip the screen buffer (double-buffered modes only) or wait for VSYNC (all modes) **
-- `VDU 23, 0, &FF`: Switch to or resume terminal mode for CP/M (This will disable keyboard entry in BBC BASIC/MOS)
+For more information on these commands and a full list, please consult the `VDU 23` section of the [VDU Commands](VDP---VDU-Commands.md) document.
 
- \* Requires VDP 1.03 or above<br>
- \** Requires VDP 1.04 or above<br>
- § Requires Console8 VDP 2.3.0 or above<br>
- §§ Requires Console8 VDP 2.4.0 or above
- 
-
-Commands between &82 and &89 will return their data back to the eZ80 via the [serial protocol](#serial-protocol).
-
-NB:
-
-- Prior to MOS 1.03 these were indexed from &00, not &80. For example, `VDU 23, 0, &02` to request the cursor position.
-
-## RTC control
-
-- `VDU 23, 0, 7, 0`: Read the RTC
-- `VDU 23, 0, 7, 1, y, m, d, h, m, s`: Set the RTC
-
-## Mouse control
-
-Commands beginning with `VDU 23, 0, &89` are reserved for mouse control, and are implemented from VDP 1.04 onwards.
-
-- `VDU 23, 0, &89, 0`: Enable the mouse
-- `VDU 23, 0, &89, 1`: Disable the mouse
-- `VDU 23, 0, &89, 2`: Reset the mouse
-- `VDU 23, 0, &89, 3, cursorId;`: Set mouse cursor
-- `VDU 23, 0, &89, 4, x; y;`: Set mouse cursor position
-- `VDU 23, 0, &89, 5, x1; y1; x2; y2;`: Reserved (Set mouse area - not yet implemented)
-- `VDU 23, 0, &89, 6, sampleRate;`: Set mouse sample rate
-- `VDU 23, 0, &89, 7, resolution;`: Set mouse resolution
-- `VDU 23, 0, &89, 8, scaling`: Set mouse scaling
-- `VDU 23, 0, &89, 9, acceleration;`: Set mouse acceleration
-- `VDU 23, 0, &89, 10, wheelAcceleration; wheelAccHighByte`: Set mouse wheel acceleration (accepts a 24-bit value)
-
-## VDU 23, 1: Cursor display
-
-- `VDU 23, 1, 0`: Disable the text cursor
-- `VDU 23, 1, 1`: Enable the text cursor
-
-## VDU 23, 7: Scrolling
-
-- `VDU 23, 7, extent, direction, speed`: Scroll the screen
-
-## VDU 23, 16: Define Cursor Behaviour (Requires VDP 1.04 or greater)
-
-- `VDU 23, 16, setting, mask`: Specify [cursor behaviour](#cursor-behaviour) by ANDing with mask then XORing with setting
-
-## VDU 23, 27: Bitmaps, sprites, and mouse cursor
-
-VDU 23, 27 is reserved for the bitmap, sprite, and mouse cursor functionality
-
-### Bitmaps
-
-- `VDU 23, 27, 0, n`: Select bitmap n (equating to buffer ID numbered 64000+`n`)
-- `VDU 23, 27, 1, w; h; b1, b2 ... bn`: Load colour bitmap data into current bitmap
-- `VDU 23, 27, 2, w; h; col1; col2;`: Create a solid colour rectangular bitmap (col1 and col2 form a 32 bit number in RGBA colour range.)
-- `VDU 23, 27, 3, x; y;`: Draw current bitmap on screen at pixel position x, y (a valid bitmap must be selected first)
-- `VDU 23, 27, &20, bufferId;`: Select bitmap using a 16-bit buffer ID
-- `VDU 23, 27, &21, w; h; format`: Create bitmap from selected buffer
-
-### Sprites
-
-- `VDU 23, 27, 4, n`: Select sprite n
-- `VDU 23, 27, 5`: Clear frames in current sprite
-- `VDU 23, 27, 6, n`: Add bitmap n as a frame to current sprite (where bitmap's buffer ID is 64000+`n`)
-- `VDU 23, 27, 7, n`: Activate n sprites
-- `VDU 23, 27, 8`: Select next frame of current sprite
-- `VDU 23, 27, 9`: Select previous frame of current sprite
-- `VDU 23, 27, 10, n`: Select the nth frame of current sprite
-- `VDU 23, 27, 11`: Show current sprite
-- `VDU 23, 27, 12`: Hide current sprite
-- `VDU 23, 27, 13, x; y;`: Move current sprite to pixel position x, y
-- `VDU 23, 27, 14, x; y;`: Move current sprite by x, y pixels
-- `VDU 23, 27, 15`: Update the sprites in the GPU
-- `VDU 23, 27, 16`: Reset bitmaps and sprites and clear all data
-- `VDU 23, 27, 17`: Reset sprites (only) and clear all data
-- `VDU 23, 27, &26, n;`: Add bitmap n as a frame to current sprite using a 16-bit buffer ID
-
-### Mouse cursor
-
-- `VDU 23, 27, &40, hotX, hotY`: Setup a mouse cursor with a hotspot at hotX, hotY from the currently selected bitmap
-
-## Serial Protocol
-
-Data sent from the VDP to the eZ80's UART0 is sent as a packet in the following format:
-
-- cmd: The packet command, with bit 7 set
-- len: Number of data bytes
-- data: The data byte(s)
-
-Words are 16 bit, and sent in little-endian format
-
-In general, as a programmer using an Agon you should not need to worry about any of these packets, as they are handled by MOS.  On receipt of one of these packets MOS sets system variables accordingly.  It will set a bit in the VDPProtocol status byte, and then whichever other system variables are relevant to the packet received.
+Within the `VDU 23` command set you will find the [Audio API](VDP---Enhanced-Audio-API.md), [Bitmap and Sprite API](VDP---Bitmaps-API.md), and [Buffered Commands API](VDP---Buffered-Commands-API).  These are all documented in their own documents.
 
 
-Packets:
 
-- `0x00`: General Poll
-- `0x01, keycode, modifiers, vkey, keydown`: Keyboard state
-- `0x02, x, y`: Cursor position
-- `0x03, char`: Character read from screen
-- `0x04, r, g, b, index`: Pixel colour read from screen
-- `0x05, channel, status`: Audio command status (see [VDP Enhanced Audio API](VDP---Enhanced-Audio-API.md))
-- `0x06, width; height; cols, rows, colours`: Screen dimensions - width and height are words
-- `0x07, year, month, day, dayOfYear, dayOfWeek, hour, minute, second`: RTC data
-- `0x08, delay, rate, led`: Keyboard status - delay and rate are words
-- `0x09, x; y; buttons, wheelDelta, deltaX; deltaY;`: Mouse status - x, y, deltaX and deltaY are words
 
-## Keyboard
 
-When a key is pressed, a packet is sent with the following data:
-- cmd: 0x01
-- keycode: The ASCII value of the key pressed
-- modifiers: A byte with the following bits set (1 = pressed):
-```
-0. CTRL
-1. SHIFT
-2. ALT LEFT
-3. ALT RIGHT
-4. CAPS LOCK
-5. NUM LOCK
-6. SCROLL LOCK
-7. GUI
-```
-From VDP 1.03, the following key data is also returned
-- vkey: The FabGL virtual keycode
-- keydown: 1 if the key is down, 0 if the key is up
 
-## Cursor Behaviour
 
-The following bits are implemented in VDU 23, 16
-
-- `Bit 0 = 1`: Enable scroll protection - text cursor will not scroll when it moves off the bottom/right of the viewport
-- `Bit 0 = 0`: Disable scroll protection (default)
-- `Bit 4 = 1`: Text cursor will wrap to top of screen when it moves off the bottom of the screen
-- `Bit 4 = 0`: Text cursor will scroll when it moves off the bottom of the screen (default)
-- `Bit 5 = 1`: Cursor does not move right after a character is printed
-- `Bit 5 = 0`: Cursor moves right after a character is printed (default)
-- `Bit 6 = 1`: Graphics cursor (VDU 5 mode) carries on off edge of graphics viewport
-- `Bit 6 = 0`: Graphics cursor does an implicit cr/lf when it moves off right of graphics viewport (default)
-
-## Screen Modes
-
-Modes over 128 are double-buffered
-
-### Prior to Version 1.04
-
-| Mode | Horz | Vert | Cols | Refresh |
-|-----:|-----:|-----:|-----:|--------:|
-| 0    | 1024 |  768 |    2 | 60hz    |
-| 1    |  512 |  384 |   16 | 60hz    |
-| 2    |  320 |  200 |   64 | 75hz    |
-| 3    |  640 |  480 |   16 | 60hz    |
-
-### From Version 1.04 or greater
-
-| Mode | Horz | Vert | Cols | Refresh |
-|-----:|-----:|-----:|-----:|--------:|
-|    0 |  640 |  480 |   16 |    60hz |
-|    1 |  640 |  480 |    4 |    60hz |
-|    2 |  640 |  480 |    2 |    60hz |
-|    3 |  640 |  240 |   64 |    60hz |
-|    4 |  640 |  240 |   16 |    60hz |
-|    5 |  640 |  240 |    4 |    60hz |
-|    6 |  640 |  240 |    2 |    60hz |
-|    8 |  320 |  240 |   64 |    60hz |
-|    9 |  320 |  240 |   16 |    60hz |
-|   10 |  320 |  240 |    4 |    60hz |
-|   11 |  320 |  240 |    2 |    60hz |
-|   12 |  320 |  200 |   64 |    70hz |
-|   13 |  320 |  200 |   16 |    70hz |
-|   14 |  320 |  200 |    4 |    70hz |
-|   15 |  320 |  200 |    2 |    70hz |
-|   16 |  800 |  600 |    4 |    60hz |
-|   17 |  800 |  600 |    2 |    60hz |
-|   18 | 1024 |  768 |    2 |    60hz |
-|  129 |  640 |  480 |    4 |    60hz |
-|  130 |  640 |  480 |    2 |    60hz |
-|  132 |  640 |  240 |   16 |    60hz |
-|  133 |  640 |  240 |    4 |    60hz |
-|  134 |  640 |  240 |    2 |    60hz |
-|  136 |  320 |  240 |   64 |    60hz |
-|  137 |  320 |  240 |   16 |    60hz |
-|  138 |  320 |  240 |    4 |    60hz |
-|  139 |  320 |  240 |    2 |    60hz |
-|  140 |  320 |  200 |   64 |    70hz |
-|  141 |  320 |  200 |   16 |    70hz |
-|  142 |  320 |  200 |    4 |    70hz |
-|  143 |  320 |  200 |    2 |    70hz |
 


### PR DESCRIPTION
Splits out the VDP documentation into several different files.

There is an expansion upon the explanation of what the VDP is and does, and how it works, attempting to better explain that at it’s heart it’s an interpreter of a VDU command stream

More detailed explanations for _all_ existing VDP commands are provided.

Documentation now included that covers what PLOT commands are supported.

Documentation on bitmaps and sprites expanded, including advice on sprite performance