### PR TITLE
Document new commands added in the 2.9.0 VDP release

### DIFF
--- a/docs/vdp/Buffered-Commands-API.md
+++ b/docs/vdp/Buffered-Commands-API.md
@@ -566,7 +566,7 @@ It is useful for contructing a single buffer from multiple sources, such as for 
 
 `VDU 23, 0, &A0, bufferId; 32, operation, [<format>, <arguments...>]`
 
-As of the time of writing, this command is experimental and subject to change.  It features in the Console8 VDP 2.9.0 test release.  The exact operations and arguments supported by this command may change in the future.
+As of the time of writing, this command is experimental and subject to change.  It features in the Console8 VDP 2.9.0 release, but to use this command you need to enable the feature by setting the affine transforms test flag.  This is done using the command `VDU 23, 0, &F8, 1; 1;`.  The exact operations and arguments supported by this command may change in the future.
 
 The purpose of this command is to create or manipulate a 2D affine transformation matrix stored in a buffer.  Affine transforms are used to manipulate 2D points, and can be used to perform operations such as translation, rotation, scaling, and shearing.
 

--- a/docs/vdp/Buffered-Commands-API.md
+++ b/docs/vdp/Buffered-Commands-API.md
@@ -562,6 +562,73 @@ This command will replace the target buffer with a new buffer that contains a si
 
 It is useful for contructing a single buffer from multiple sources, such as for constructing a bitmap from multiple constituent parts.
 
+## Command 32: Create or maniplate a 2D affine transformation matrix
+
+`VDU 23, 0, &A0, bufferId; 32, operation, [<format>, <arguments...>]`
+
+As of the time of writing, this command is experimental and subject to change.  It features in the Console8 VDP 2.9.0 test release.  The exact operations and arguments supported by this command may change in the future.
+
+The purpose of this command is to create or manipulate a 2D affine transformation matrix stored in a buffer.  Affine transforms are used to manipulate 2D points, and can be used to perform operations such as translation, rotation, scaling, and shearing.
+
+To use this API you do not need to understand the mathematics of affine transformations.  The API is designed to be simple to use, and to allow for complex transformations to be built up from simple operations.
+
+Technically, a 2D affine transformation matrix is a 3x3 matrix that can be used to perform transformations on 2D points, and can be applied to drawing operations.  The matrix is stored in row-major order, and is stored as 32-bit single-precision IEEE-754 floating point values.  The matrix is stored in a single block in the buffer.  The drawing system may store a second block in the buffer to cache an inverse of the matrix, but you should not rely on that being there.
+
+A challenge with this API is that inherently neither the VDU command system nor the eZ80 CPU support floating-point arithmetic.  The API therefore supports sending numbers across in a variety of different formats to help facilitate this, and will convert the values sent to floating-point values as required.  The API supports sending fixed-point values, 16-bit and 32-bit integers, and 16-bit and 32-bit floating-point values.  Values must just be sent across as bytes in the VDU command stream in little-endian order, much like any other value byte must be send.
+
+Several different operations are supported by this command.  When an operation is performed, the result is stored back in the buffer, replacing any existing data that may have been there.  Most operations will combine their result with the existing matrix in the buffer.  This means that you can combine for instance rotation and scaling into one transform matrix.  The following operations are supported:
+
+| Operation | Arguments | Description |
+| --------- | -------------- | ----------- |
+| 0 | 0 | Set an "identity matrix" (effectively a "reset" operation) |
+| 1 | 0 | Invert the matrix (this will only succeed if the buffer already contains a valid transform matrix) |
+| 2 | 1 | Rotate anticlockwise by angle in degrees |
+| 3 | 1 | Rotate anticlockwise by angle in radians |
+| 4 | 1 | Multiply all values in the first 8 matrix positions by an amount |
+| 5 | 2 | Scale X and Y by given scaling factors |
+| 6 | 2 | Translate X and Y by a number of pixels |
+| 7 | 2 | Translate X and Y by using currently selected graphics coordinate system units |
+| 8 | 2 | Shear X and Y by given amounts |
+| 9 | 2 | Skew X and Y by angle in degrees |
+| 10 | 2 | Skew X and Y by angle in radians |
+| 11 | 6 | Transform (combine with another transform matrix - requires 6 values to be sent - the final matrix row will be set to 0, 0, 1) |
+
+Repeatedly calling this command with different operations will build up a transform matrix in the buffer.  It should be noted that if the buffer is not cleared out before starting to build up a new matrix (or set to an identity matrix) then the results may not be as expected.
+
+Every operation that requires arguments to be provided must then send a byte to indicate the format of the arguments that follow.  The format byte is as follows:
+
+| Bit value | Description |
+| --- | ----------- |
+| 0-4 | Shift (used for fixed-point values, ignored for floating-point) |
+| 5 | Unused, must be zero (Reserved for future use) |
+| 6 | When set, data is provided in fixed-point format, otherwise it is IEEE-754 floating point |
+| 7 | When set, data is presented as 16-bit values, otherwise they are 32-bit values |
+
+The fixed-point format supported by this command essentially means that values sent will be interpreted as a binary number with a "binary point".  The binary point starts out to the right of the right-most bit of the value (the least significant bit), meaning that when a shift value of zero is used the number being sent is an integer.  A shift of 1 will move the binary point one place to the left, effectively dividing the number by 2.  A shift of 2 will divide the number sent by 4, and so on.  
+
+The shift value is a 5-bit value, and its use varies depending on whether a 16-bit or a 32-bit value is being sent (i.e. if bit 7 has been set).  When a 32-bit value is sent (bit 7 is clear), the shift is interpretted as a 5-bit unsigned integer, i.e. it has the range of 0-31.  For 16-bit values, the 5-bit shift is a signed integer, giving a range of -16 to +15.  This allows for a negative shift to be applied to 16-bit values, meaning the number sent will be multiplied by 2 when a shift of -1 is given, by 4 for a shift of -2, and so on.
+
+As can be seen, the API also supports sending IEEE-754 floating point values.  These can be sent either as single-precision values (using 32-bits), or as half-precision values (in 16-bits).  The "shift" bits in the format byte will be ignored when sending floating-point values.  A format value of `0` therefore indicates that values will be sent as 32-bit single-precision IEEE-754 floating point values, and a format value of `&80` indicates values will be sent as 16-bit half-precision IEEE-754 values.
+
+In all cases data should be sent in little-endian byte order.
+
+### Advanced operations
+
+Similar to the Adjust command, it is possible to perform some advanced operations with this command by setting some of the upper bits of the operation byte.  The following bits are defined:
+
+| Bit value | Description |
+| --- | ----------- |
+| &10 | Use advanced offsets (when using buffer-fetched values) |
+| &20 | Fetch values from a buffer (and offset), rather than the command stream |
+| &40 | Separate arguments will have individual format bytes |
+
+The most important of these is the "fetch values from a buffer" bit.  When this bit is set, a format byte is still read from the VDU command stream, but then the next two bytes in the stream are interpreted as a buffer ID, which should then be followed by an offset (2 further bytes, unless the "use advanced offsets" bit is set).  The value to be used in the operation will then be fetched from the buffer at the given offset, and interpretted using the format described in the format byte.  Using this allows for transform matrices to be built up over time in multiple buffers, and then combined into a single buffer.  This can be useful for building up complex transformations in a modular way.
+
+When this flag is set, all arguments are fetched from the given buffer, at the given offset.  If the operation requires multiple bytes they will be read consecutively from the buffer.  The format byte is still used to interpret the values fetched from the buffer.
+
+When the "Separate arguments have individual format bits" flag is set then each argument will be prefaced with its own format byte, rather than a single byte being used to dictate the format of all arguments.  This can be useful when sending multiple arguments of different types.  This can be combined with the other flags.
+
+
 ## Command 64: Compress a buffer
 
 `VDU 23, 0, &A0, targetBufferId; 64, sourceBufferId;`

--- a/docs/vdp/Buffered-Commands-API.md
+++ b/docs/vdp/Buffered-Commands-API.md
@@ -562,7 +562,7 @@ This command will replace the target buffer with a new buffer that contains a si
 
 It is useful for contructing a single buffer from multiple sources, such as for constructing a bitmap from multiple constituent parts.
 
-## Command 32: Create or maniplate a 2D affine transformation matrix
+## Command 32: Create or manipulate a 2D affine transformation matrix
 
 `VDU 23, 0, &A0, bufferId; 32, operation, [<format>, <arguments...>]`
 

--- a/docs/vdp/PLOT-Commands.md
+++ b/docs/vdp/PLOT-Commands.md
@@ -186,6 +186,8 @@ Before a bitmap plot can be used a valid bitmap must be selected using either `V
 
 Bitmap plots will only draw non-transparent pixels to the screen.  When using "foreground" PLOTs, the bitmap is drawn to screen using the current foreground GCOL painting mode using the colour from the bitmap.  When using "background" PLOTs, the bitmap is drawn to screen using the current background GCOL painting mode using the currently selected background colour.  Inverse plot modes invert on-screen pixels that correspond to non-transparent pixels in the bitmap.
 
+As of Console8 VDP version 2.9.0 it is possible to set an affine transform matrix to be applied to bitmap plots.  This allows for bitmaps to be scaled, rotated, sheared, and translated when being drawn onto the screen.  The transform matrix is set using `VDU 23, 0, &96, 1, bufferId;` which is documented in the [System Commands](System-Commands.md) documentation.  The buffered commands API provides commands to set and manipluate the transform matrix, and is documented in the [Buffered Commands](Buffered-Commands-API.md) documentation.
+
 
 ## PLOT support prior to VDP 1.04
 

--- a/docs/vdp/System-Commands.md
+++ b/docs/vdp/System-Commands.md
@@ -340,6 +340,10 @@ Until Console8 VDP 2.6.0, this control key behaviour on the VDP was always enabl
 
 From Console8 VDP 2.6.0 onwards, the control keys can be turned off, which may help ensure that unexpected behaviour on the VDP does not occur when using applications running on MOS that may also wish to use these control key combinations.
 
+## `VDU 23, 0, &9B, bufferId;`: Print the contents of a buffer to the screen §§§§§§
+
+If a buffer is found with the given `bufferId`, then this command will print a buffer out to the screen, using only the raw character values. This bypasses VDU command processing, so no control characters at all are supported and will be printed as-is.
+
 ## `VDU 23, 0, &9C`: Set the text viewport using graphics coordinates §§§§§
 
 Sets the text viewport using the rectangle described by the last two coordinates given via PLOT commands.  This command serves a similar purpose to `VDU 28`, but uses graphics coordinates instead of text coordinates, and does not require the coordinates to be sent as part of the command.  This allows for more flexibility in defining the viewport.

--- a/docs/vdp/System-Commands.md
+++ b/docs/vdp/System-Commands.md
@@ -305,7 +305,7 @@ This command is used to manage fonts on your system.  For more information pleas
 
 ## `VDU 23, 0, &96, <flags>, <bufferId>;`: Set an affine transform matrix §§§§§§
 
-As of the time of writing, this command is experimental and subject to change.  It features in the Console8 VDP 2.9.0 test release.
+As of the time of writing, this command is experimental and subject to change.  To enable it you must turn on the affine transform feature flag, using the `VDU 23, 0, &F8, 1; 1;` command.
 
 This command tells the graphics system to use an affine transform matrix held within the given buffer for subsequent drawing commands.  This allows for the transformation of graphics when they are drawn in a variety of ways, including scaling, rotation, and translation.
 
@@ -422,6 +422,23 @@ The line pattern can be set using `VDU 23, 6, n1, n2, n3, n4, n5, n6, n7, n8`, w
 
 Support for this command was added in Console8 VDP 2.7.0.
 
+## `VDU 23, 0, &F8, flagId; value;`: Set a test flag §§§§§§
+
+This command is used to set a test flag.  Test flags are used to enable new and experimental features in the VDP that may not be quite ready for general use, and/or have an API that may change in the future.  They are intended for use by developers and testers.
+
+The `flagId` is the ID of the flag to set, and the `value` is the value to set the flag to.  The meaning of the `value` that any particular flag is set to will be specific to the flag being set.  A value must always be provided, even if the flag does not require a value to be set.
+
+As of Console8 VDP 2.9.0 the following test flags are supported:
+
+| Flag ID | Value | Description |
+| ------- | ----- | ----------- |
+| 1 | 0 (N/A) | Enable the Affine Transforms feature |
+
+If a flag is set that is not recognised then it will have no effect.  This means that if a feature graduates from being a test feature then so long as the API for the feature remains the same, then software that set the flag to enable the feature will still work.
+
+## `VDU 23, 0, &F9, flagId;`: Clear a test flag §§§§§§
+
+This command is used to clear a test flag.
 
 ## `VDU 23, 0, &FE, n`: Console mode **
 


### PR DESCRIPTION
Documents affine transforms, print buffer, expand bitmap, and set and clear test flag commands.