### PR TITLE
Add navigation to VDP subsections to side navigation bar

### DIFF
--- a/docs/MOS-API.md
+++ b/docs/MOS-API.md
@@ -88,6 +88,7 @@ Parameters:
 - `A`: Stream delimiter (if `BC`=0)
 
 Returns:
+
 - `A`: Last character displayed (length mode) OR Delimeter (delimeter mode)
 - `BC`: 0
 - `HL(U)`: Address of last character displayed + 1 (length mode) OR location of delimeter (delimeter mode)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,11 +61,23 @@ nav:
     - 'Start here': index.md
     - 'FAQ': FAQ.md
     - 'Theory of operation': Theory-of-operation.md
-  - 'Reference':
-    - 'MOS': MOS.md
-    - 'VDP': VDP.md
-    - 'BBC Basic': BBC-BASIC-for-Agon.md
-    - 'GPIO': GPIO.md
+  - 'MOS':
+      - 'Command line': MOS.md
+      - 'API': MOS-API.md
+  - 'VDP':
+    - 'Overview': VDP.md
+    - 'Main Commands': vdp/VDU-Commands.md
+    - 'Screen Modes': vdp/Screen-Modes.md
+    - 'PLOT Commands': vdp/PLOT-Commands.md
+    - 'System Commands': vdp/System-Commands.md
+    - 'Audio API': vdp/Enhanced-Audio-API.md
+    - 'Bitmaps and Sprites API': vdp/Bitmaps-API.md
+    - 'Buffered Commands API': vdp/Buffered-Commands-API.md
+    - 'Context Management API': vdp/Context-Management-API.md
+    - 'Font Management API': vdp/Font-API.md
+
+  - 'BBC Basic': BBC-BASIC-for-Agon.md
+  - 'GPIO': GPIO.md
   - 'Guides':
     - 'Updating Firmware': Updating-Firmware-from103.md
     - 'Updating Firmware (prio v1.03)': Updating-Firmware.md


### PR DESCRIPTION
I added links to all the VDP subsection docs to the sidebar to make it easier to get to them without having to find the links within other pages.

![image](https://github.com/AgonConsole8/agon-docs/assets/947942/a9243c59-e52f-4f06-b557-d79f7fcb23b0)
