### PR TITLE
document new transform commands

### DIFF
--- a/docs/vdp/Buffered-Commands-API.md
+++ b/docs/vdp/Buffered-Commands-API.md
@@ -776,6 +776,17 @@ The various different values that pixels will be mapped to should immediately fo
 When a buffer is used for mapping data, that buffer must exist, and must contain a single block of at least the number of values required for the given number of bits per pixel.
 
 
+## Command 128: Debug info command
+
+`VDU 23, 0, &A0, bufferId; 128`
+
+This command is a debugging command that will print out info on a buffer to the USB serial console.  This is useful for debugging purposes, and can be used to check the contents of a buffer after a series of operations have been performed on it.
+
+The info printed to the console will tell you how many blocks/streams are stored against the `bufferId`.  If the buffer contains a transform matrix, then the matrix will be printed out in a human-readable format.  For other buffers the whole of the first block/stream will be output to the console in hexadecimal format.  NB the whole block/stream will be output, so be aware that if the buffer is large then a lot of data will be sent to the console.
+
+Before Console8 VDP 2.10.0 this command would only work if you were using a VDP compiled with the `DEBUG` flag set.  As of Console8 VDP 2.10.0 this command will now work without the flag being set.
+
+
 ## Examples
 
 What follows are some examples of how the VDP Buffered Commands API can be used to perform various tasks.

--- a/docs/vdp/Buffered-Commands-API.md
+++ b/docs/vdp/Buffered-Commands-API.md
@@ -562,19 +562,20 @@ This command will replace the target buffer with a new buffer that contains a si
 
 It is useful for constructing a single buffer from multiple sources, such as for constructing a bitmap from multiple constituent parts.
 
-## Command 32: Create or manipulate a 2D affine transformation matrix
+## Commands 32 and 33: Create or manipulate a 2D or 3D affine transformation matrix
 
 `VDU 23, 0, &A0, bufferId; 32, operation, [<format>, <arguments...>]`
+`VDU 23, 0, &A0, bufferId; 33, operation, [<format>, <arguments...>]`
 
-As of the time of writing, this command is experimental and subject to change.  It features in the Console8 VDP 2.9.0 release, but to use this command you need to enable the feature by setting the affine transforms test flag.  This is done using the command `VDU 23, 0, &F8, 1; 1;`.  The exact operations and arguments supported by this command may change in the future.
+As of the time of writing, this command is experimental and subject to change.  It features in the Console8 VDP 2.9.0 release, but to use this command you need to enable the feature by setting the affine transforms test flag.  This is done using the command `VDU 23, 0, &F8, 1; 1;`.  The exact operations and arguments supported by this command may change in the future.  Command 33 was added in the Console8 VDP 2.10.0 release.
 
-The purpose of this command is to create or manipulate a 2D affine transformation matrix stored in a buffer.  Affine transforms are used to manipulate 2D points, and can be used to perform operations such as translation, rotation, scaling, and shearing.
+The purpose of these commands is to create or manipulate an affine transform matrix stored in a buffer.  Affine transforms are used to manipulate 2D or 3D points, and can be used to perform operations such as translation, rotation, scaling, and shearing.  Command 32 creates or manipulates a 2D affine transform matrix, and command 33 creates or manipulates a 3D affine transform matrix.  Affine transforms are used to manipulate 2D or 3D points, and can be used to perform operations such as translation, rotation, scaling, and shearing.
 
 To use this API you do not need to understand the mathematics of affine transformations.  The API is designed to be simple to use, and to allow for complex transformations to be built up from simple operations.
 
-Technically, a 2D affine transformation matrix is a 3x3 matrix that can be used to perform transformations on 2D points, and can be applied to drawing operations.  The matrix is stored in row-major order, and is stored as 32-bit single-precision IEEE-754 floating point values.  The matrix is stored in a single block in the buffer.  The drawing system may store a second block in the buffer to cache an inverse of the matrix, but you should not rely on that being there.
+Technically, a 2D affine transformation matrix is a 3x3 matrix that can be used to perform transformations on 2D points, and can be applied to drawing operations.  A 3D affine transform uses a 4x4 matrix to account for the extra dimension.  The matrix is stored in row-major order, and is stored as 32-bit single-precision IEEE-754 floating point values.  The matrix is stored in a single block in the buffer.  The drawing system may store a second block in the buffer to cache an inverse of the matrix, but you should not rely on that being there.
 
-A challenge with this API is that inherently neither the VDU command system nor the eZ80 CPU support floating-point arithmetic.  The API therefore supports sending numbers across in a variety of different formats to help facilitate this, and will convert the values sent to floating-point values as required.  The API supports sending fixed-point values, 16-bit and 32-bit integers, and 16-bit and 32-bit floating-point values.  Values must just be sent across as bytes in the VDU command stream in little-endian order, much like any other value byte must be send.
+A challenge with this API is that inherently neither the VDU command system nor the eZ80 CPU directly support floating-point arithmetic.  The API therefore supports sending numbers across in a variety of different formats to help facilitate this, and will convert the values sent to floating-point values as required.  The API supports sending fixed-point values, 16-bit and 32-bit integers, and 16-bit and 32-bit floating-point values.  Values must just be sent across as bytes in the VDU command stream in little-endian order, much like any other value byte must be send.
 
 Several different operations are supported by this command.  When an operation is performed, the result is stored back in the buffer, replacing any existing data that may have been there.  Most operations will combine their result with the existing matrix in the buffer.  This means that you can combine for instance rotation and scaling into one transform matrix.  The following operations are supported:
 
@@ -582,16 +583,16 @@ Several different operations are supported by this command.  When an operation i
 | --------- | -------------- | ----------- |
 | 0 | 0 | Set an "identity matrix" (effectively a "reset" operation) |
 | 1 | 0 | Invert the matrix (this will only succeed if the buffer already contains a valid transform matrix) |
-| 2 | 1 | Rotate anticlockwise by angle in degrees |
-| 3 | 1 | Rotate anticlockwise by angle in radians |
+| 2 | 1 (3 for 3D) | Rotate anticlockwise by angle in degrees |
+| 3 | 1 (3 for 3D) | Rotate anticlockwise by angle in radians |
 | 4 | 1 | Multiply all values in the first 8 matrix positions by an amount |
-| 5 | 2 | Scale X and Y by given scaling factors |
-| 6 | 2 | Translate X and Y by a number of pixels |
-| 7 | 2 | Translate X and Y by using currently selected graphics coordinate system units |
-| 8 | 2 | Shear X and Y by given amounts |
-| 9 | 2 | Skew X and Y by angle in degrees |
-| 10 | 2 | Skew X and Y by angle in radians |
-| 11 | 6 | Transform (combine with another transform matrix - requires 6 values to be sent - the final matrix row will be set to 0, 0, 1) |
+| 5 | 2 (3 for 3D) | Scale X and Y (and Z for 3D) by given scaling factors |
+| 6 | 2 (3 for 3D) | Translate X and Y (and Z for 3D) by a number of pixels |
+| 7 | 2 (3 for 3D) | Translate X and Y by using currently selected graphics coordinate system units, (Z transform in pixels for 3D version) |
+| 8 | 2 (3 for 3D) | Shear X and Y by given amounts |
+| 9 | 2 (3 for 3D) | Skew X and Y by angle in degrees |
+| 10 | 2 (3 for 3D) | Skew X and Y by angle in radians |
+| 11 | 6 (12 for 3D) | Transform (combine with another transform matrix - requires 6 values to be sent, or 12 values for 3D - the final matrix row will be set to `0, 0, 1`, or `0, 0, 0, 1` for a 3D matrix) |
 
 Repeatedly calling this command with different operations will build up a transform matrix in the buffer.  It should be noted that if the buffer is not cleared out before starting to build up a new matrix (or set to an identity matrix) then the results may not be as expected.
 
@@ -599,10 +600,10 @@ Every operation that requires arguments to be provided must then send a byte to 
 
 | Bit value | Description |
 | --- | ----------- |
-| 0-4 | Shift (used for fixed-point values, ignored for floating-point) |
-| 5 | Unused, must be zero (Reserved for future use) |
-| 6 | When set, data is provided in fixed-point format, otherwise it is IEEE-754 floating point |
-| 7 | When set, data is presented as 16-bit values, otherwise they are 32-bit values |
+| 0-&1F | Shift (used for fixed-point values, ignored for floating-point) |
+| &20 | Unused, must be zero (Reserved for future use) |
+| &40 | When set, data is provided in fixed-point format, otherwise it is IEEE-754 floating point |
+| &80 | When set, data is presented as 16-bit values, otherwise they are 32-bit values |
 
 The fixed-point format supported by this command essentially means that values sent will be interpreted as a binary number with a "binary point".  The binary point starts out to the right of the right-most bit of the value (the least significant bit), meaning that when a shift value of zero is used the number being sent is an integer.  A shift of 1 will move the binary point one place to the left, effectively dividing the number by 2.  A shift of 2 will divide the number sent by 4, and so on.
 
@@ -627,6 +628,103 @@ The most important of these is the "fetch values from a buffer" bit.  When this 
 When this flag is set, all arguments are fetched from the given buffer, at the given offset.  If the operation requires multiple bytes they will be read consecutively from the buffer.  The format byte is still used to interpret the values fetched from the buffer.
 
 When the "Separate arguments have individual format bits" flag is set then each argument will be prefaced with its own format byte, rather than a single byte being used to dictate the format of all arguments.  This can be useful when sending multiple arguments of different types.  This can be combined with the other flags.
+
+
+## Command 34: Create or combine a matrix of arbitrary dimensions
+
+`VDU 23, 0, &A0, bufferId; 23, operation, rows, columns, [<arguments>]`
+
+As of the time of writing, this command is experimental and subject to change.  It features in the Console8 VDP 2.10.0 release, but to use this command you need to enable the feature by setting the affine transforms test flag.  This is done using the command `VDU 23, 0, &F8, 1; 1;`.  The exact operations and arguments supported by this command may change in the future.
+
+This command expands on commands 32 and 33 to allow for the creation of a matrix of arbitrary dimensions.  The matrix is stored in a buffer, and is stored in row-major order.  The matrix is stored as 32-bit single-precision IEEE-754 floating point values.  The matrix is stored in a single block in the buffer.
+
+This command works in a similar manner to commands 32 and 33, and where applicable supports the same floating point data formats.  The operations supported by this command are as follows:
+
+| Operation | Arguments | Description |
+| --------- | -------------- | ----------- |
+| 0 | `format, <arguments...>` | Set the matrix to the values provided |
+| 1 | `sourceBufferId; row, column, format, <arguments...>` | Copy source matrix and set an individual value |
+| 2 | `format, <value>` | Create a matrix with all entries filled with the given value |
+| 3 | `format, <value>` | Create a matrix filled with zeros and set the diagonal to the given value |
+| 4 | `sourceBufferId1; sourceBufferId2;` | Add two matrices together |
+| 5 | `sourceBufferId1; sourceBufferId2;` | Subtract matrices (target = source1 - source2) |
+| 6 | `sourceBufferId1; sourceBufferId2;` | Multiply two matrices together |
+| 7 | `sourceBufferId; format, <value>` | Multiply matrix by a scalar value |
+| 8 | `sourceBufferId; row, column` | Extract a sub-matrix from a source matrix at given row and column. Target matrix will be filled from top-left, truncating or padding with zeros as necessary |
+| 9 | `sourceBufferId; row` | Create a new copy of the source matrix, inserting a row at given offset |
+| 10 | `sourceBufferId; column` | Create a new copy of the source matrix, inserting a column at given offset |
+| 11 | `sourceBufferId; row` | Create a new copy of the source matrix, removing a row at given offset |
+| 12 | `sourceBufferId; column` | Create a new copy of the source matrix, removing a column at given offset |
+
+The target matrix will always be created with the number of rows and columns given in the command.  If the source matrix is not the same size as the target matrix then the source matrix will be truncated or padded with zeros as necessary.
+
+When multiplying two different matrixes together, usually it is required that the second matrix will have the same number of rows as there are columns in the first matrix.  This command however will allow different matrixes of different dimensions to be multiplied together.  It does this by making the matrixes square and padding with zeros where necessary, where the square size is the maximum of the dimensions of the sources and target matrixes.
+
+
+### Advanced operations
+
+Similar to commands 32 and 33, it is possible to perform some advanced operations with this command by setting some of the upper bits of the operation byte.  The following bits are defined:
+
+| Bit value | Description |
+| --- | ----------- |
+| &10 | Use advanced offsets (when using buffer-fetched values) |
+| &20 | Fetch values from a buffer (and offset), rather than the command stream |
+
+
+## Command 40: Create a transformed a bitmap
+
+`VDU 23, 0, &A0, bufferId; 40, options, transformBufferId; sourceBitmapId; [width; height;]`
+
+As of the time of writing, this command is experimental and subject to change.  It features in the Console8 VDP 2.10.0 release, but to use this command you need to enable the feature by setting the affine transforms test flag.  This is done using the command `VDU 23, 0, &F8, 1; 1;`.  The exact options and arguments supported by this command may change in the future.
+
+This command applies an affine transformation to a bitmap, creating a new RGBA2222 format bitmap.  It will replace the target buffer with the new bitmap, and creates a corresponding bitmap.
+
+The `options` parameter is an 8-bit value that can have bits set to modify the behaviour of the operation.  The following bits are defined, and can be combined together:
+
+| Bit value | Arguments | Description |
+| --- | --- | ----------- |
+| 1 |  | Target bitmap should be resized.  When _not_ set, target will be same dimensions as the original bitmap. |
+| 2 | `width; height;`| Target bitmap will be resized to explicitly given dimensions
+| 4 |  | Automatically translate target bitmap position.  When set the calculated transformed minimum x,y coordinates will be placed at the top left of the target |
+
+Usually the target bitmap will be the same size as the source bitmap, but it is possible to resize the target bitmap to a different size.  When no explicit size is given, but the "resize" bit has been set, then the target bitmap size will depend on the transformation being applied.  This could mean, for example, that applying a progressive series of rotations to a bitmap can result in several different sizes of target bitmap.
+
+
+## Command 41: Apply a transform matrix to data in a buffer
+
+`VDU 23, 0, &A0, bufferId; 41, options, format, transformBufferId; sourceBufferId; [<arguments>]`
+
+As of the time of writing, this command is experimental and subject to change.  It features in the Console8 VDP 2.10.0 release, but to use this command you need to enable the feature by setting the affine transforms test flag.  This is done using the command `VDU 23, 0, &F8, 1; 1;`.  The exact options and arguments supported by this command may change in the future.
+
+This command will copy the source buffer and transform sets of values held within it using the given format and transform matrix.  The transformed values will be stored in the target buffer, replacing any existing data that may have been there.  The options byte, and optional arguments (depending on which bits of the options byte are set), control how the transformation is applied.
+
+The `options` parameter is an 8-bit value that can have bits set to modify the behaviour of this command, including which arguments should be sent.  The following bits are defined, and can be combined together:
+
+| Bit value | Arguments | Description |
+| --- | --- | ----------- |
+| &01 | `size` | Explicit data set size (otherwise data size will be one less than the number of rows in the transform matrix) |
+| &02 | `offset;` | Has an offset into the buffer for where to find the first data set (NB this may be an "advanced offset" if that option is set) |
+| &04 | `stride;` | Has an explicit stride (in bytes) between value sets |
+| &08 | `limit;` | Has an explicit limit to the number of data items to be transformed |
+| &10 |  | "Advanced offsets" should be used |
+| &20 |  | Optional argument values should be fetched from buffers (and thus be a bufferId and offset in the command stream) |
+| &40 |  | Data transforms should be applied on a block-by-block basis on data in the source buffer |
+
+The `format` argument indicates the format of data in the source buffer, using the same format as for the affine transform commands.  This means that values to be transformed will be interpretted either as fixed-point or floating-point values in either 16 or 32 bits.  Using fixed-point format with a shift value of zero will interpret the values as integers (e.g. a format of `&C0` means source data is in 16-bit integers).  Data in the target buffer will be stored in the same format as the source buffer.
+
+This command works with sets of data.  Typically if you are using this command to transform 2D points the size of the data set will be two, to indicate that you're transforming two values, the X and Y coordinates.  These sets of data values must appear contiguously in the source buffer.  The `stride` dictates how far apart (in bytes) the start of each set of data lies in the source buffer.  The `limit` parameter can be used to limit the number of data sets that are transformed.
+
+As an example, this command can be used to transform sets of coordinates in a buffer that contains a series of PLOT commands.  A complete PLOT VDU command is a sequence of 6 bytes, where the first byte is `25` for PLOT, the second byte is the PLOT operation code, and then there are two 16-bit integer values for the X and Y coordinates.  The `offset` therefore would be set to `2`, and the `stride` would be set to `6`.  Our `format` needs to indicate we are using 16-bit fixed-point values with no shift, so that equates to `&C0`.  As we wish to set an explicit (start) offset and stride we need an `options` value of `6` (which is 2 + 4).  A command to use a 2D transform matrix stored in buffer `10` on a command sequence the data stored in buffer 20, writing the transformed data to buffer 30, would look like this:
+
+```
+VDU 23, 0, &A0, 30; 41, 6, &C0, 10; 20; 2; 6;
+```
+
+This example makes two significant assumptions.  The first, as mentioned above, is that the source buffer only contains a series of PLOT commands.  The second assumption is that we are using a 2D affine transform matrix created by command 32, which will have created a 3x3 matrix, and therefore an explicit `size` argument is not needed - it will be automatically derived as a data set size of 2, i.e. X and Y coordinates.
+
+Once this example command has been executed, buffer 30 would contain the same sequence of PLOT commands as buffer 20, but with the X and Y coordinates transformed by the matrix stored in buffer 10.  Buffer 30 could then be called, and a transformed version of the PLOT commands would be drawn on the screen.
+
+It should be noted that since it is only the coordinates that are transformed, the nature of the PLOT commands themselves will not be changed.  If the transform matrix was created with only "translate" or "scale" operations then the effect will work as expected for all PLOT commands (except for bitmap plots, which would not be drawn scaled as only the target coordinates woulld have changed), but if the transform included "rotate", "shear" or "skew" then results may differ.  PLOT commands that only draw lines, or fill triangles, will draw properly transformed versions of those shapes.  The effect on some other PLOT commands, such as those to fill a rectangle, or plot a circle/arc/sector will differ, as it is just the coordinates that are being transformed.  A rectangle may be drawn with a different size, but its sides will still be drawn aligned to the X and Y axis, and a circle will still be round.
 
 
 ## Command 64: Compress a buffer

--- a/docs/vdp/Screen-Modes.md
+++ b/docs/vdp/Screen-Modes.md
@@ -86,6 +86,10 @@ Modes over 128 are double-buffered
 |   16 |  800 |  600 |    4 |    60hz |
 |   17 |  800 |  600 |    2 |    60hz |
 |   18 | 1024 |  768 |    2 |    60hz |
+| § 20 |  512 |  384 |   64 |    60hz |
+| § 21 |  512 |  384 |   16 |    60hz |
+| § 22 |  512 |  384 |    4 |    60hz |
+| § 23 |  512 |  384 |    2 |    60hz |
 |  129 |  640 |  480 |    4 |    60hz |
 |  130 |  640 |  480 |    2 |    60hz |
 |  132 |  640 |  240 |   16 |    60hz |
@@ -99,12 +103,17 @@ Modes over 128 are double-buffered
 |  141 |  320 |  200 |   16 |    70hz |
 |  142 |  320 |  200 |    4 |    70hz |
 |  143 |  320 |  200 |    2 |    70hz |
+| § 149 |  512 |  384 |   16 |    60hz |
+| § 150 |  512 |  384 |    4 |    60hz |
+| § 151 |  512 |  384 |    2 |    60hz |
 
 \* Mode 1 is the "default" mode, and is the mode that the system will use on startup.  It is also the mode that the system will fall back to use if it was not possible to change to the requested mode.
 
 \** Mode 7 is the "Teletext" mode, and essentially works in a very similar manner to the BBC Micro's Teletext mode, which was also mode 7.
 
 \*** As of Console8 VDP 2.8.0, mode 0 is now the mode that the VDP will use on startup.  The fallback mode when a requested mode is not available remains mode 1.
+
+§ Support for screen modes 20-23 and 149-151 was added in Console8 VDP 2.10.0
 
 ### Legacy modes (prior to 1.04)
 

--- a/docs/vdp/Screen-Modes.md
+++ b/docs/vdp/Screen-Modes.md
@@ -22,7 +22,7 @@ There are two VDU commands that will affect the screen modes that are available,
 
 This command selects a screen mode, where the screen mode is a single byte value and must be a mode from the list below.
 
-Screen modes numbered above 128 are double-buffered, meaning that the screen is drawn to an off-screen buffer, and then the buffer is copied to the screen.  This prevents flickering when drawing to the screen.
+Screen modes numbered above 128 are double-buffered, meaning that the screen is drawn to an off-screen buffer, and then the buffer is copied to the screen.  This prevents flickering when drawing to the screen.  Double-buffered mode numbers are equivalent to a regular mode with 128 added.  Please note that owing to memory limitations not all screen modes can be double-buffered.
 
 As drawing operations, when in a double-buffered mode, are only performed in the off-screen buffer this means that the screen will not be updated until the active buffer is swapped.  This means, for instance, that if you enter a double-buffered screen mode in BASIC by using `MODE 129` then commands that you type will not be visible, as your input is being written to the off-screen buffer.  Commands will still be processed, but you will only see their effect when the buffer is swapped.  Buffers are swapped using `VDU 23, 0, &C3`
 
@@ -86,6 +86,7 @@ Modes over 128 are double-buffered
 |   16 |  800 |  600 |    4 |    60hz |
 |   17 |  800 |  600 |    2 |    60hz |
 |   18 | 1024 |  768 |    2 |    60hz |
+| § 19 | 1024 |  768 |    4 |    60hz |
 | § 20 |  512 |  384 |   64 |    60hz |
 | § 21 |  512 |  384 |   16 |    60hz |
 | § 22 |  512 |  384 |    4 |    60hz |
@@ -103,6 +104,8 @@ Modes over 128 are double-buffered
 |  141 |  320 |  200 |   16 |    70hz |
 |  142 |  320 |  200 |    4 |    70hz |
 |  143 |  320 |  200 |    2 |    70hz |
+| § 145 |  800 |  600 |    2 |    60hz |
+| § 146 | 1024 |  768 |    2 |    60hz |
 | § 149 |  512 |  384 |   16 |    60hz |
 | § 150 |  512 |  384 |    4 |    60hz |
 | § 151 |  512 |  384 |    2 |    60hz |
@@ -113,7 +116,7 @@ Modes over 128 are double-buffered
 
 \*** As of Console8 VDP 2.8.0, mode 0 is now the mode that the VDP will use on startup.  The fallback mode when a requested mode is not available remains mode 1.
 
-§ Support for screen modes 20-23 and 149-151 was added in Console8 VDP 2.10.0
+§ Support for screen modes 19-23, 145-146 and 149-151 was added in Console8 VDP 2.10.0
 
 ### Legacy modes (prior to 1.04)
 


### PR DESCRIPTION
Preliminary documentation for the new commands added to the buffered commands API for creating transform matrixes, and applying those matrixes to data.

This includes creating 3d transform matrixes, creating matrixes of arbitrary size, creating a transformed bitmap using a 2d transform, and transforming data held within a buffer