### PR TITLE
Fix mkdocs.yml errors

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,6 @@ theme:
     - search.highlight
     - content.tabs.link
     - content.code.annotate
-    - content.code.annotation
     - content.code.copy
     - content.footnote.tooltips
     - content.action.edit

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,7 +28,6 @@ theme:
     - navigation.sections
     - navigation.expand
     - navigation.instant
-    - navigation.instant.preview
     - navigation.top
     - search.suggest
     - search.highlight

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,16 +40,22 @@ theme:
     - content.action.edit
   language: en
   palette:
-    - scheme: default
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
       toggle:
         icon: material/toggle-switch-off-outline
         name: Switch to dark mode
       primary: deep purple
       accent: purple
-    - scheme: slate
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       toggle:
         icon: material/toggle-switch
-        name: switch to light mode
+        name: Switch to your system preference
       primary: deep purple
       accent: lime
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,8 +50,8 @@ theme:
       toggle:
         icon: material/toggle-switch
         name: switch to light mode
-        primary: deep purple
-        accent: lime
+      primary: deep purple
+      accent: lime
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION

This pull request addresses several issues related the MkDocs theme configuration and navigation settings that I had discovered while re-configuring my environment. The following changes have been made in this pull request:

## Fixed:
  - Corrected the indentation of the primary and accent colors for dark mode to ensure proper rendering (it wasn't being applied correctly so was reverting the default blue).
  - Removed `navigation.instant.preview` as it is only applicable to [insiders](https://squidfunk.github.io/mkdocs-material/insiders/) and doesn't apply for our use.
  - Fixed an invalid annotation feature by removing `content.code.annotation`.

## Addition:
  - Configured the theme to have a third state which is an automatic value between dark and light modes based on user preferences in their local OS.
