### PR TITLE
Update sublists to use 4 spaces to render in HTML

### DIFF
--- a/docs/External-Documentation.md
+++ b/docs/External-Documentation.md
@@ -11,7 +11,7 @@
 
 # [Zilog](https://www.zilog.com)
 - eZ80F92 Documentation
-  - [eZ80 CPU](http://www.zilog.com/docs/um0077.pdf)
-  - [Specification](https://www.zilog.com/docs/ez80/ps0130.pdf)
-  - [Calling C Functions from Assembly and Vice Versa](https://www.zilog.com/docs/appnotes/an0333.pdf)
-  - [ZDSII User Manual](http://www.zilog.com/docs/devtools/um0144.pdf)
+    - [eZ80 CPU](http://www.zilog.com/docs/um0077.pdf)
+    - [Specification](https://www.zilog.com/docs/ez80/ps0130.pdf)
+    - [Calling C Functions from Assembly and Vice Versa](https://www.zilog.com/docs/appnotes/an0333.pdf)
+    - [ZDSII User Manual](http://www.zilog.com/docs/devtools/um0144.pdf)

--- a/docs/MOS-API.md
+++ b/docs/MOS-API.md
@@ -22,9 +22,9 @@ NB:
 
 - Using the `RST.LIS` opcode in an eZ80 assembler will ensure the MOS RST instructions are called regardless of the eZ80s current addressing mode.
 - In the `mos_api.inc` file you will find:
-  - EQUs for all the MOS commands, data structures and system variables.
-  - An incomplete list of VDP control variables.  For a full list, see the [VDP documentation](VDP.md)
-  - A complete list FatFS APIs, however these are not yet all implemented in MOS.  Those that are implemented are documented below.
+    - EQUs for all the MOS commands, data structures and system variables.
+    - An incomplete list of VDP control variables.  For a full list, see the [VDP documentation](VDP.md)
+    - A complete list FatFS APIs, however these are not yet all implemented in MOS.  Those that are implemented are documented below.
 
 Further information on the `RST` handlers provided by MOS are as follows:
 

--- a/docs/Updating-Firmware.md
+++ b/docs/Updating-Firmware.md
@@ -61,9 +61,9 @@ Once this has succeeded the Agon will not work properly until you upgrade VDP.
 2. Remove the SD card and return to your PC
 3. Copy bbcbasic.bin to the root directory, overwriting any existing file
 4. Copy the following folders to the root directory to update the examples (optional, but recommended)
-   - examples
-   - resources
-   - tests
+    - examples
+    - resources
+    - tests
 5. Eject the SD card and return it to the Agon
 
 #### 3. Update the VDP

--- a/docs/vdp/System-Commands.md
+++ b/docs/vdp/System-Commands.md
@@ -115,7 +115,7 @@ Returns the screen dimensions to MOS.  Generally applications should not need to
 This command controls the Real Time Clock within the Agon VDP.
 
 - `VDU 23, 0, &87, 0`: Read the RTC
-  - a data packet will be sent to MOS with the current RTC data, and MOS system variables updated accordingly
+    - a data packet will be sent to MOS with the current RTC data, and MOS system variables updated accordingly
 
 - `VDU 23, 0, &87, 1, y, m, d, h, m, s`: Set the RTC
 


### PR DESCRIPTION
To render properly in the HTML conversion, it needs 4 spaces for a markdown sublist in python even though github shows them as sublists with only 2 spaces.